### PR TITLE
Restructured CPM with chemotaxis extension

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,34 @@
-
+2018-03-29 Inge Wortel <ingewortel@gmail.com>
+	* src/CPM.js : rewritten with new javascript "class" syntax. Also restructured the 
+	code, implemented a dynamic computation of the hamiltonian. The attribute 
+	"this.terms" contains the terms of the Hamiltonian to be considered. By default, the 
+	terms are ["adhesion","volume","perimeter", "actmodel"]. The basic CPM class also 
+	supports terms "connectivity" and "invasiveness", but these are not part of the 
+	Hamiltonian by default. Add them by typing eg C.terms.push["connectivity"]. Changed
+	"var" to the new "const" and "let" wherever possible.
+	* src/CPM.js ( deltaH ) : computes the Hamiltonian depending on this.terms.
+	Also logs Hamiltonian terms to the console if this.logterms = true.
+	* src/CPM.js ( deltaHadhesion, deltaHvolume, deltaHperimeter, deltaHconnectivity, 
+	deltaHinvasiveness, deltaHactmodel ) : new functions to compute the different terms
+	of the Hamiltonian. 
+	* src/CPM.js ( deltaHconnectivity ) : changed so that it computes the cost appropriately
+	in a case where both the source and target cell have a non-zero lambda connectivity.
+	* src/CPM.js ( monteCarloStep ) : simplified, now computes Hamiltonian via a call to
+	deltaH instead of within the function itself.
+	* src/CPM.js ( neighi2D, neighi3D ) : changed order of output of
+	the neighbourhood pixels, which fixes the bug in the connectivity constraint.
+	* src/CPM.js ( neighC2D, neighC3D ) : changed into a method because the new class
+	syntax requires this.
+	* src/CPMchemotaxis.js : rewritten to extend the CPM class according to the new syntax.
+	This now also works in node.
+	* examples-node/run-2d-chemokine.js : added an example of chemotaxis in node.
+	* examples-node/Makefile : modified to make movie of the chemotaxis example.
+	* examples-node & examples-browser : added the line C.addStromaBorder() where 
+	necessary to prevent cells from moving off te grid. (The stroma border was present by
+	default in an earlier version, but not anymore).
+	* src/CPMStats.js : changed computation of orderindex for normalized version, using
+	only the cellborderpixels.
+	
 2018-03-22 Inge Wortel <ingewortel@gmail.com>
 	* src/CPMStats.js : added functions to compute percentage of active pixels in a cell.
 	* src/CPMStats.js : added functions to compute order index of the act gradient in a cell.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2018-03-15 Inge Wortel <ingewortel@gmail.com>
+	* src/CPM.js (pointAttractor) : small adjustment in pointAttractor
+	* src/CPMchemotaxis.js : added new class to extend the CPM with a chemokine gradient.
+
 2018-03-06 Inge Wortel <ingewortel@gmail.com>
 
 	* src/CPM.js : adjusted the computation of X_BITS, Y_BITS, Z_BITS (number of bits was higher than necessary, which limited the possible grid size in 3D too much). Turned off the default generation of a stroma border.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2018-03-22 Inge Wortel <ingewortel@gmail.com>
+	* src/CPMCanvas.js : added functions to compute percentage of active pixels in a cell.
+
 2018-03-20 Inge Wortel <ingewortel@gmail.com>
 	* src/CPMCanvas.js : small change in creating canvas in line with commit in jtextor
 	* src/CPMStats.js : Added functions from jtextor to compute "connectedness" of the cell

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 
 2018-03-22 Inge Wortel <ingewortel@gmail.com>
-	* src/CPMCanvas.js : added functions to compute percentage of active pixels in a cell.
+	* src/CPMStats.js : added functions to compute percentage of active pixels in a cell.
+	* src/CPMStats.js : added functions to compute order index of the act gradient in a cell.
 
 2018-03-20 (2) Inge Wortel <ingewortel@gmail.com>
 	* src/BGCanvas.js : added special class to create a chemokine canvas to be copied

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2018-03-20 Inge Wortel <ingewortel@gmail.com>
+	* src/CPMCanvas.js : small change in creating canvas in line with commit in jtextor
+	* src/CPMStats.js : Added functions from jtextor to compute "connectedness" of the cell
+	* examples-node/run-2d.js : now logs connectedness to the console.
+
+
 2018-03-15 Inge Wortel <ingewortel@gmail.com>
 	* src/CPM.js (pointAttractor) : small adjustment in pointAttractor
 	* src/CPMchemotaxis.js : added new class to extend the CPM with a chemokine gradient.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+2018-02-28 Inge Wortel <ingewortel@gmail.com>
+
+	* src/CPMStats.js (getCentroids, getCentroidOf, centroids) : replaced separate 2D/3D functions with a single function. getCentroids and centroid now call getCentroidOf internally.
+
+	* src/CPMStats.js (updateOnline, newOnline, cellStats) : new functions to compute mean and variance of pixel coordinates in a given dimension (0,1,2 for x,y,z).
+
+	* src/CPMStats.js (getLengthOf, getRangeOf) : new functions to compute the length of a cell in a given dimension. getLengthOf actually returns the variance (a little more robust); getRangeOf returns the distance between the outer pixels in a given dimension.
+
+	* src/CPMCanvas.js (this.wrap) : an array "wrap" can now be passed to options, useful for displaying large grids. The grid is displayed as a smaller grid of size "wrap" with linked borders (using modulo operations on the coordinates). If left unspecified, this.wrap is [0,0,0] -- indicating no wrapping in x,y,and z dimensions. See also this.i2p (below).
+
+	* src/CPMCanvas.js (this.i2p) : replaces this.C.i2p to compute pixel coordinates for drawing. this.i2p also implements modulo operations for wrapping (see above), to convert grid coordinates to the coordinates on the smaller grid.
+
 2018-01-29 Inge Wortel <ingewortel@gmail.com>
 	
 	* src/CPMStats.js (centroids2D,centroids3D) : fixed eslint no-console error.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2018-03-06 Inge Wortel <ingewortel@gmail.com>
+
+	* src/CPM.js : adjusted the computation of X_BITS, Y_BITS, Z_BITS (number of bits was higher than necessary, which limited the possible grid size in 3D too much). Turned off the default generation of a stroma border.
+
+	* src/CPM.js ( addStromaBorder ) : this implementation did not work for 3D (produced stroma lines instead of planes at the grid border, so no real barrier for the cells). Instead, this now uses a new function addStromaPlane.
+
+	* src/CPMCanvas.js : changed the generation of the canvas in the html document so that its size depends on the field size and the wrap option (before, only the drawing of cells was wrapped, but not the canvas itself).
+
+
 2018-02-28 Inge Wortel <ingewortel@gmail.com>
 
 	* src/CPMStats.js (getCentroids, getCentroidOf, centroids) : replaced separate 2D/3D functions with a single function. getCentroids and centroid now call getCentroidOf internally.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2018-03-20 (2) Inge Wortel <ingewortel@gmail.com>
+	* src/BGCanvas.js : added special class to create a chemokine canvas to be copied
+	onto the CPMCanvas.
+	* src/CPMchemotaxis.js : instead of altering CPMCanvas, now use BGCanvas.
+	* examples-node/2d-chemokine.html : added example of chemotaxis
+
 2018-03-20 Inge Wortel <ingewortel@gmail.com>
 	* src/CPMCanvas.js : small change in creating canvas in line with commit in jtextor
 	* src/CPMStats.js : Added functions from jtextor to compute "connectedness" of the cell

--- a/examples-browser/2d-chemokine.html
+++ b/examples-browser/2d-chemokine.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>Chemokine gradient</title>
+<meta charset="utf-8">
+<script type="text/javascript" src="../src/DiceSet.js"></script>
+<script type="text/javascript" src="../src/CPM.js"></script>
+<script type="text/javascript" src="../src/CPMStats.js"></script>
+<script type="text/javascript" src="../src/CPMCanvas.js"></script>
+<script type="text/javascript" src="../src/CPMchemotaxis.js"></script>
+<script type="text/javascript" src="../src/BGCanvas.js"></script>
+<script type="text/javascript">
+
+
+/* An example 2D CPM with multiple cells of different kinds, and multiple
+visualizations. */
+
+
+var C,Cim,t=0, burnin_time=100, runtime=10000, zoom=2, wrap=[0,0]
+
+function initialize(){
+
+	// Create a CPM object
+	C = new CPM( 2, {x: 400, y:200}, {
+		LAMBDA_CHEMOTAXIS : [0,30],
+		LAMBDA_CONNECTIVITY : [0,0],
+		LAMBDA_P : [0,2],
+		LAMBDA_V : [0,30],
+		LAMBDA_ACT : [0,50],
+		MAX_ACT : [0,40],
+		P : [0,260],
+		V : [0,500],
+		J_T_STROMA : [NaN,15],
+		J_T_ECM : [NaN,20],
+		J_T_T : [ [NaN,NaN], [NaN,100] ],
+		T : 20,
+		ACT_MEAN : "geometric",
+		GRADIENT_TYPE : "linear",
+		GRADIENT_DIRECTION : [1,0]
+	})
+
+	// Create a canvas to draw on
+	Cim = new CPMCanvas( C, {zoom:zoom, wrap:wrap} )
+	Cimgradient = new BGCanvas( C, {zoom:zoom, wrap:wrap} )
+	Cimgradient.drawChemokineGradient( "0061ff" )
+	C.addStromaBorder()
+	C.stop = false
+
+
+	
+	// simulation
+	startsim()
+}
+
+function startsim(){
+	// Seed cell
+	for( i = 0 ; i < 2 ; i ++ ){
+		C.seedCellAt( 1, [50,100] )
+	}
+
+	// Burnin phase: only start drawing after the first burnin_time MCS
+	// (because cells need to increase their volume first)
+	for( i = 0 ; i < burnin_time ; i ++ ){
+		C.monteCarloStep()
+	}
+	timestep()
+}
+
+// Continue until the maximum simulation time is reached. 
+function timestep(){
+
+	// Update the grid with one MCS
+	C.monteCarloStep()
+
+	// Clear the canvas (white),add gradient, and draw the stroma border in gray
+	Cim.ctx.clearRect(0,0,this.Cim.el.width,this.Cim.el.height)
+	Cim.ctx.drawImage( Cimgradient.el,0,0)
+	Cim.drawStroma( "AAAAAA" )
+
+	// Draw celltype 1 black with activity values
+	Cim.drawCells( 1, "000000")
+	Cim.drawActivityValues( 1 )
+
+	// Draw the borders of each cell
+	Cim.drawCellBorders()
+
+	if( t++ < runtime && !C.stop ){
+		requestAnimationFrame( timestep )
+	}
+}
+
+function startSim(){
+	C.stop = false
+	timestep()
+}
+
+function stopSim(){
+	C.stop = true
+}
+
+function reset(){
+		stopSim()
+		// remove all cells from the grid, but keep stroma		
+		var cellpix1 = C.cellpixelstype, cellpix = Object.keys( cellpix1 ), i
+		for( i = 0; i < cellpix.length; i++ ){
+			if( cellpix1[i] != 0 ){
+				C.delpixi( cellpix[i] )
+			}
+		}
+		// Also remove the cellborderpixels
+		C.cellborderpixels = new DiceSet()
+	
+}
+
+
+
+</script>
+</script>
+<body onload="initialize()">
+
+<div>
+<button onclick="startSim()">start</button>
+<button onclick="stopSim()">stop</button>
+<button onclick="reset();startsim();timestep()">reset</button>
+<br><br>
+</div>
+<div class="slidecontainer">
+<table>
+<tr><td>Max<sub>Act</sub></td><td>
+0<input type="range" min="0" max="100" value="40" class="slider" id="maxact" 
+  oninput="C.conf.MAX_ACT[1]=this.value">100
+</td></tr>
+<tr><td>&lambda;<sub>Act</sub></td><td>
+0<input type="range" min="0" max="1000" value="200" class="slider" id="lambdaact" 
+  oninput="C.conf.LAMBDA_ACT[1]=this.value">1000
+</td></tr>
+<tr><td>&lambda;<sub>Chemotaxis</sub></td><td>
+0<input type="range" min="0" max="100" value="30" class="slider" id="lchem" 
+  oninput="C.conf.LAMBDA_CHEMOTAXIS[1]=this.value">100
+  </td></tr></table>
+</div>
+
+
+</body>
+</html>
+

--- a/examples-browser/2d-chemokine.html
+++ b/examples-browser/2d-chemokine.html
@@ -20,7 +20,7 @@ var C,Cim,t=0, burnin_time=100, runtime=10000, zoom=2, wrap=[0,0]
 function initialize(){
 
 	// Create a CPM object
-	C = new CPM( 2, {x: 400, y:200}, {
+	C = new CPMchemotaxis( 2, {x: 400, y:200}, {
 		LAMBDA_CHEMOTAXIS : [0,30],
 		LAMBDA_CONNECTIVITY : [0,0],
 		LAMBDA_P : [0,2],

--- a/examples-browser/2d.html
+++ b/examples-browser/2d.html
@@ -32,7 +32,7 @@ function initialize(){
 		T : 20,
 		ACT_MEAN : "geometric" 
 	})
-
+	C.addStromaBorder()
 	// Create a canvas to draw on
 	Cim = new CPMCanvas( C )
 

--- a/examples-browser/single-amoeboid-cell.html
+++ b/examples-browser/single-amoeboid-cell.html
@@ -27,6 +27,7 @@ function initialize(){
 		T : 20,
 		ACT_MEAN : "geometric"
 	})
+	C.addStromaBorder()
 
 	// Create canvas, stats, and track object
 	Cim = new CPMCanvas( C, {zoom:zoom} )

--- a/examples-node/Makefile
+++ b/examples-node/Makefile
@@ -6,6 +6,12 @@ output/2d.mp4 : output/0.png
 output/0.png : run-2d.js
 	node $< 5 python 2img.py
 
+output/2dchemokine0.png : run-2d-chemokine.js
+	node $< 10 python 2img.py
+
+output/2dchemokine.mp4 : output/2dchemokine0.png
+	ffmpeg -y -framerate 10 -i output/2dchemokine%d.png -c:v libx264 -r 30 -pix_fmt yuv420p output/2dchemokine.mp4
+
 clean:
 	rm -f output/*
 

--- a/examples-node/run-2d-chemokine.js
+++ b/examples-node/run-2d-chemokine.js
@@ -1,0 +1,66 @@
+/** Run a CPM in 2D, and print centroids of all cells. Also save an image each [framerate=10] monte carlo steps
+    after a burnin phase of [burnin=50] Monte Carlo Steps. */
+
+//var CPM = require("../src/CPM.js")
+var CPMchemotaxis = require("../src/CPMchemotaxis.js")
+var BGCanvas = require("../src/BGCanvas.js")
+var CPMStats = require("../src/CPMStats.js")
+var CPMCanvas = require("../src/CPMCanvas.js")
+
+var burnin=50, maxtime=5000
+
+var framerate = parseInt(process.argv[2]) || 10
+
+var C = new CPMchemotaxis( 2, {x: 400, y:200}, {
+	LAMBDA_CHEMOTAXIS : [0,30],
+	LAMBDA_CONNECTIVITY : [0,0],
+	LAMBDA_P : [0,2],
+	LAMBDA_V : [0,30],
+	LAMBDA_ACT : [0,50],
+	MAX_ACT : [0,40],
+	P : [0,260],
+	V : [0,500],
+	J_T_STROMA : [NaN,15],
+	J_T_ECM : [NaN,20],
+	J_T_T : [ [NaN,NaN], [NaN,100] ],
+	T : 20,
+	ACT_MEAN : "geometric",
+	GRADIENT_TYPE : "linear",
+	GRADIENT_DIRECTION : [1,0]
+})
+
+var Cstat = new CPMStats( C )
+var Cim = new CPMCanvas( C )
+var Cimgradient = new BGCanvas( C )
+Cimgradient.drawChemokineGradient( "0061ff" )
+C.addStromaBorder()
+var t = 0
+
+// Seed cells
+var i
+for( i = 0 ; i < 2 ; i ++ ){
+	C.seedCellAt( 1, [50,100] )
+}
+
+// burnin phase (let cells gain volume)
+for( i = 0 ; i < burnin ; i ++ ){
+	C.monteCarloStep()
+}
+
+// actual simulation
+for( i = 0 ; i < maxtime ; i ++ ){
+	C.monteCarloStep()
+	Cstat.centroids()
+	//console.log( Cstat.getConnectedness() )
+	if( i % framerate == 0 ){
+		//Cim.ctx.clearRect(0,0,Cim.el.width,Cim.el.height)
+		Cim.clear("FFFFFF")
+		Cim.ctx.drawImage( Cimgradient.el,0,0)
+		Cim.drawStroma( "AAAAAA" )
+		Cim.drawCells( 1, "000000")
+		Cim.drawActivityValues( 1 )
+		Cim.drawCellBorders( "FFFFFF" )
+		Cim.writePNG( "output/2dchemokine"+t+".png" )
+		t ++
+	}
+}

--- a/examples-node/run-2d.js
+++ b/examples-node/run-2d.js
@@ -44,6 +44,7 @@ for( i = 0 ; i < burnin ; i ++ ){
 for( i = 0 ; i < maxtime ; i ++ ){
 	C.monteCarloStep()
 	Cstat.centroids()
+	console.log( Cstat.getConnectedness() )
 	if( i % framerate == 0 ){
 		Cim.clear( "FFFFFF" )
 		//Cim.drawCells( 2, "990000" )

--- a/examples-node/run-2d.js
+++ b/examples-node/run-2d.js
@@ -25,12 +25,13 @@ var C = new CPM( 2, {x: fieldSize, y:fieldSize}, {
 	T : 20,
 	ACT_MEAN : "geometric" 
 })
-
+C.addStromaBorder()
 var Cstat = new CPMStats( C )
 var Cim = new CPMCanvas( C )
 var t = 0
 
 // Seed cells
+var i
 for( i = 0 ; i < nrCells ; i ++ ){
 	C.seedCell()
 }

--- a/examples-node/run-3d.js
+++ b/examples-node/run-3d.js
@@ -22,7 +22,7 @@ var C = new CPM( 3, {x: fieldSize, y:fieldSize, z:fieldSize}, {
 	T : 7,
 	ACT_MEAN : "arithmetic"
 })
-
+C.addStromaBorder()
 var Cstat = new CPMStats( C )
 
 // Seed nrCells of kind 1 and kind 2

--- a/src/BGCanvas.js
+++ b/src/BGCanvas.js
@@ -1,0 +1,132 @@
+/* This class creates a canvas of the size of the current CPM for drawing
+backgrounds. It is not appended to the html page by default but can be copied
+as a whole to quickly draw a chemokine gradient onto an existing CPMCanvas. */
+
+// Constructor
+function BGCanvas( C, options ){
+	this.C = C
+	this.zoom = (options && options.zoom) || 1
+	this.wrap = (options && options.wrap) || [0,0,0]
+	this.width = this.wrap[0]
+	this.height = this.wrap[1]
+
+	if( this.width == 0 || this.C.field_size.x < this.width ){
+		this.width = this.C.field_size.x
+	}
+	if( this.height == 0 || this.C.field_size.y < this.height ){
+		this.height = this.C.field_size.y
+	}
+
+	if( typeof document !== "undefined" ){
+		this.el = document.createElement("canvas")
+		this.el.width = this.width*this.zoom
+		this.el.height = this.height*this.zoom//C.field_size.y*this.zoom
+		//var parent_element = (options && options.parentElement) || document.body
+		//parent_element.appendChild( this.el )
+	} else {
+		const {createCanvas} = require("canvas")
+		this.el = createCanvas( this.width*this.zoom,
+			this.height*this.zoom )
+		this.fs = require("fs")
+	}
+
+	this.ctx = this.el.getContext("2d")
+	this.ctx.lineWidth = .2
+	this.ctx.lineCap="butt"
+}
+
+
+BGCanvas.prototype = {
+
+
+	/* Several internal helper functions (used by drawing functions below) : */
+	pxf : function( p ){
+		this.ctx.fillRect( this.zoom*p[0], this.zoom*p[1], this.zoom, this.zoom )
+	},
+
+	pxfnozoom : function( p ){
+		this.ctx.fillRect( this.zoom*p[0], this.zoom*p[1], 1, 1 )
+	},
+
+	/* For easier color naming */
+	col : function( hex ){
+		this.ctx.fillStyle="#"+hex
+	},
+	/* Color the whole grid in color [col] */
+	clear : function( col ){
+		col = col || "000000"
+		this.ctx.fillStyle="#"+col
+		this.ctx.fillRect( 0,0, this.el.width, this.el.height )
+	},
+
+	context : function(){
+		return this.ctx
+	},
+
+	i2p : function( i ){
+		var p = this.C.i2p( i ), dim
+		for( dim = 0; dim < p.length; dim++ ){
+			if( this.wrap[dim] != 0 ){
+				p[dim] = p[dim] % this.wrap[dim]
+			}
+		}
+		return p
+	},
+
+	/* DRAWING FUNCTIONS ---------------------- */
+
+
+	setopacity : function( alpha ){
+		this.ctx.globalAlpha = alpha
+	},
+	chemokineIntensity : function( p ){
+
+		var gradienttype = this.C.conf["GRADIENT_TYPE"]
+		var gradientvec = this.C.conf["GRADIENT_DIRECTION"]
+
+		if( gradienttype == "linear" ){
+			var gmax = gradientvec[0]*this.C.field_size.x + gradientvec[1]*this.C.field_size.y
+			var gval = 0.0 + (gradientvec[0]*p[0]) + ( gradientvec[1]*p[1] )
+			return( gval/gmax )
+		} else if( gradienttype == "radial" ){
+			var maxx = gradientvec[0], maxy = gradientvec[1]
+			if( this.C.field_size.x - maxx > maxx ){
+				maxx = this.C.field_size.x - maxx
+			}
+			if( this.C.field_size.y - maxy > maxy ){
+				maxy = this.C.field_size.y - maxy
+			}
+			var distx = p[0] - gradientvec[0], disty = p[1] - gradientvec[1]
+			var gmax = Math.sqrt( maxx*maxx + maxy*maxy )
+			var gval = 0.0 + Math.sqrt( distx*distx + disty*disty )
+
+		} else {
+			throw("Unknown gradienttype")
+		}
+		return (1-gval/gmax)
+	},
+	drawChemokineGradient : function( col ){
+
+		var i,j,alpha
+		col = col || "000000"
+		this.col( col )
+
+		for( i = 0; i < this.C.field_size.x; i++ ){
+			for( j = 0; j < this.C.field_size.y; j++ ){
+				alpha = 1*this.chemokineIntensity( [i,j] )
+				this.setopacity( alpha*alpha )
+				this.pxf( [i,j] )
+			}
+		}
+		this.setopacity( 1 )
+
+	}
+
+
+}
+
+/* This allows using the code in either the browser or with nodejs. */
+if( typeof module !== "undefined" ){
+	module.exports = BGCanvas
+}
+

--- a/src/BGCanvas.js
+++ b/src/BGCanvas.js
@@ -83,10 +83,12 @@ BGCanvas.prototype = {
 
 		var gradienttype = this.C.conf["GRADIENT_TYPE"]
 		var gradientvec = this.C.conf["GRADIENT_DIRECTION"]
+		let gmax, gval
+
 
 		if( gradienttype == "linear" ){
-			var gmax = gradientvec[0]*this.C.field_size.x + gradientvec[1]*this.C.field_size.y
-			var gval = 0.0 + (gradientvec[0]*p[0]) + ( gradientvec[1]*p[1] )
+			gmax = gradientvec[0]*this.C.field_size.x + gradientvec[1]*this.C.field_size.y
+			gval = 0.0 + (gradientvec[0]*p[0]) + ( gradientvec[1]*p[1] )
 			return( gval/gmax )
 		} else if( gradienttype == "radial" ){
 			var maxx = gradientvec[0], maxy = gradientvec[1]
@@ -97,8 +99,8 @@ BGCanvas.prototype = {
 				maxy = this.C.field_size.y - maxy
 			}
 			var distx = p[0] - gradientvec[0], disty = p[1] - gradientvec[1]
-			var gmax = Math.sqrt( maxx*maxx + maxy*maxy )
-			var gval = 0.0 + Math.sqrt( distx*distx + disty*disty )
+			gmax = Math.sqrt( maxx*maxx + maxy*maxy )
+			gval = 0.0 + Math.sqrt( distx*distx + disty*disty )
 
 		} else {
 			throw("Unknown gradienttype")

--- a/src/CPM.js
+++ b/src/CPM.js
@@ -2,110 +2,112 @@
 	Usable from browser and node.js.
 */
     
- 
-function CPM( ndim, field_size, conf ){
 
-	// Attributes based on input parameters
-	this.field_size = field_size			/* grid size ( Note: the grid will run from 0 to 
-							field_size pixels, so the actual size in pixels is
-							one larger. ) */
-	this.ndim = ndim				// grid dimensions (2 or 3)
-	this.conf = conf				// input parameter settings; see documentation.
+class CPM {
 
-	// Some functions/attributes depend on ndim:
-	if( ndim == 2 ){
+	constructor( ndim, field_size, conf ){
 	
-		// wrapper functions:
-		//this.neigh = this.neigh2D		/* returns coordinates of neighbor pixels
-		//					(including diagonal neighbors) */
-		this.neighi = this.neighi2D		/* same, but with pixel index as in/output */
-		this.neighC = this.neighC2D		/* returns indices of neighbor pixels
-							(excluding diagnoal neighbors) */
-		this.p2i = this.p2i2D			// converts pixel coordinates to a unique ID
-		this.i2p = this.i2p2D			// converts pixel ID to coordinates
+		// Attributes based on input parameters
+		this.field_size = field_size			/* grid size ( Note: the grid will run from 0 to 
+								field_size pixels, so the actual size in pixels is
+								one larger. ) */
+		this.ndim = ndim				// grid dimensions (2 or 3)
+		this.conf = conf				// input parameter settings; see documentation.
 
-		this.field_size.z = 1			// for compatibility
-		this.midpoint = 			// middle pixel in the grid.
-		[ 	Math.round((this.field_size.x-1)/2),
-			Math.round((this.field_size.y-1)/2) ] //,0 ]
-
-	} else {
+		// Some functions/attributes depend on ndim:
+		if( ndim == 2 ){
 	
-		// wrapper functions: 
-		//this.neigh = this.neigh3D		/* returns coordinates of neighbor pixels
-		//					(including diagonal neighbors) */
-		this.neighi = this.neighi3D		/* same, but with pixel index as in/output */
-		this.neighC = this.neighC3D		/* returns indices of neighbor pixels
-							(excluding diagnoal neighbors) */
-		this.p2i = this.p2i3D			// converts pixel coordinates to a unique ID
-		this.i2p = this.i2p3D			// converts pixel ID to coordinates
+			// wrapper functions:
+			//this.neigh = this.neigh2D		/* returns coordinates of neighbor pixels
+			//					(including diagonal neighbors) */
+			this.neighi = this.neighi2D		/* same, but with pixel index as in/output */
+			this.neighC = this.neighC2D		/* returns indices of neighbor pixels
+								(excluding diagnoal neighbors) */
+			this.p2i = this.p2i2D			// converts pixel coordinates to a unique ID
+			this.i2p = this.i2p2D			// converts pixel ID to coordinates
 
-		this.midpoint = 
-		[	Math.round((this.field_size.x-1)/2),
-			Math.round((this.field_size.y-1)/2),
-			Math.round((this.field_size.z-1)/2) ]
+			this.field_size.z = 1			// for compatibility
+			this.midpoint = 			// middle pixel in the grid.
+			[ 	Math.round((this.field_size.x-1)/2),
+				Math.round((this.field_size.y-1)/2) ] //,0 ]
+
+		} else {
+	
+			// wrapper functions: 
+			//this.neigh = this.neigh3D		/* returns coordinates of neighbor pixels
+			//					(including diagonal neighbors) */
+			this.neighi = this.neighi3D		/* same, but with pixel index as in/output */
+			this.neighC = this.neighC3D		/* returns indices of neighbor pixels
+								(excluding diagnoal neighbors) */
+			this.p2i = this.p2i3D			// converts pixel coordinates to a unique ID
+			this.i2p = this.i2p3D			// converts pixel ID to coordinates
+
+			this.midpoint = 
+			[	Math.round((this.field_size.x-1)/2),
+				Math.round((this.field_size.y-1)/2),
+				Math.round((this.field_size.z-1)/2) ]
+		}
+
+
+		// Check that the grid size is not too big to store pixel ID in 32-bit number,
+		// and allow fast conversion of coordinates to unique ID numbers.
+		this.X_BITS = 1+Math.floor( Math.log2( this.field_size.x - 1 ) )
+		this.X_MASK = (1 << this.X_BITS)-1 
+
+		this.Y_BITS = 1+Math.floor( Math.log2( this.field_size.y - 1 ) )
+		this.Y_MASK = (1 << this.Y_BITS)-1
+
+		this.Z_BITS = 1+Math.floor( Math.log2( this.field_size.z - 1 ) )
+		this.Z_MASK = (1 << this.Z_BITS)-1
+
+		this.dy = 1 << this.Y_BITS // for neighborhoods based on pixel index
+		this.dz = 1 << ( this.Y_BITS + this.Z_BITS )
+
+
+		if( this.X_BITS + this.Y_BITS + this.Z_BITS > 32 ){
+			throw("Field size too large -- field cannot be represented as 32-bit number")
+		} 
+
+		// Attributes of the current CPM as a whole:
+		this.nNeigh = this.neighi(0).length 		// neighbors per pixel (depends on ndim)
+		this.nr_cells = 0				// number of cells currently in the grid
+		this.time = 0					// current system time in MCS
+	
+		// track border pixels for speed (see also the DiceSet data structure)
+		this.cellborderpixels = new DiceSet()
+		this.bgborderpixels = new DiceSet() 
+
+		// Attributes per pixel:
+		this.cellpixelsbirth = {}		// time the pixel was added to its current cell.
+		this.cellpixelstype = {}		// celltype (identity) of the current pixel.
+		this.stromapixelstype = {}		// celltype (identity) for all stroma pixels.
+
+		// Attributes per cell:
+		this.cellvolume = []			
+		this.cellperimeter = []		
+		this.t2k = []				// celltype ("kind"). Example: this.t2k[1] is the celltype of cell 1.
+		this.t2k[0] = 0
+
+		// Wrapper: select function to compute activities based on ACT_MEAN in conf
+		if( this.conf.ACT_MEAN == "arithmetic" ){
+			this.activityAt = this.activityAtArith
+		} else {
+			this.activityAt = this.activityAtGeom
+		}
+		
+		// terms to use in the Hamiltonian
+		this.terms = ["adhesion","volume","perimeter","actmodel"] //,"connectivity"]
+	
 	}
 
 
-	// Check that the grid size is not too big to store pixel ID in 32-bit number,
-	// and allow fast conversion of coordinates to unique ID numbers.
-	this.X_BITS = 1+Math.floor( Math.log2( this.field_size.x - 1 ) )
-	this.X_MASK = (1 << this.X_BITS)-1 
-
-	this.Y_BITS = 1+Math.floor( Math.log2( this.field_size.y - 1 ) )
-	this.Y_MASK = (1 << this.Y_BITS)-1
-
-	this.Z_BITS = 1+Math.floor( Math.log2( this.field_size.z - 1 ) )
-	this.Z_MASK = (1 << this.Z_BITS)-1
-
-	this.dy = 1 << this.Y_BITS // for neighborhoods based on pixel index
-	this.dz = 1 << ( this.Y_BITS + this.Z_BITS )
-
-
-	if( this.X_BITS + this.Y_BITS + this.Z_BITS > 32 ){
-		throw("Field size too large -- field cannot be represented as 32-bit number")
-	} 
-
-	// Attributes of the current CPM as a whole:
-	this.nNeigh = this.neighi(0).length 		// neighbors per pixel (depends on ndim)
-	this.nr_cells = 0				// number of cells currently in the grid
-	this.time = 0					// current system time in MCS
-	
-	// track border pixels for speed (see also the DiceSet data structure)
-	this.cellborderpixels = new DiceSet()
-	this.bgborderpixels = new DiceSet() 
-
-	// Attributes per pixel:
-	this.cellpixelsbirth = {}		// time the pixel was added to its current cell.
-	this.cellpixelstype = {}		// celltype (identity) of the current pixel.
-	this.stromapixelstype = {}		// celltype (identity) for all stroma pixels.
-
-	// Attributes per cell:
-	this.cellvolume = []			
-	this.cellperimeter = []		
-	this.t2k = []				// celltype ("kind"). Example: this.t2k[1] is the celltype of cell 1.
-	this.t2k[0] = 0
-
-	// Wrapper: select function to compute activities based on ACT_MEAN in conf
-	if( this.conf.ACT_MEAN == "arithmetic" ){
-		this.activityAt = this.activityAtArith
-	} else {
-		this.activityAt = this.activityAtGeom
-	}
-	
-	// (For function: see below.) By default the borders of the grid are set to stroma,
-	// which prevents the cell from moving out of the grid.
-	//this.addStromaBorder()
-}
-
-CPM.prototype = {
 
 	/* ------------- GETTING/SETTING PARAMETERS --------------- */
 
 	/* 	helper to get cell-dependent parameters from conf.
 		"name" is the parameter name, the 2nd/3rd arguments (optional) are
 		the celltypes (identities) to find parameter settings for. */
-	par : function( name ){
+	par( name ){
 		if( arguments.length == 2 ){
 			return this.conf[name][this.cellKind( arguments[1] ) ]
 		}
@@ -113,9 +115,10 @@ CPM.prototype = {
 			return this.conf[name][this.cellKind(arguments[1] ) ][
 				this.cellKind( arguments[2] ) ]
 		}
-	},
+	}
+	
 	/*  Get adhesion between two cells with type (identity) t1,t2 from "conf" using "this.par". */
-	J : function( t1, t2 ){
+	J( t1, t2 ){
 		if( t1 == 0 ){
 			// Adhesion between ECM and non-background/non-stroma cell
 			if( t2 > 0 ){
@@ -142,145 +145,104 @@ CPM.prototype = {
 			// adhesion ECM-ECM or ECM-stroma is 0.
 			return 0
 		}
-	},
+	}
+	
 	/* Get celltype/identity (pixt) or cellkind (pixk) of the cell at coordinates p or index i. */
-	pixt : function( p ){
+	pixt( p ){
 		return this.pixti( this.p2i(p) )
-	},
-	pixti : function( i ){
+	}
+	pixti( i ){
 		return this.cellpixelstype[i] || this.stromapixelstype[i] || 0
-	},
-	pixki : function( i ){
+	}
+	pixki( i ){
 		return this.cellKind( this.pixti(i) )
-	},
+	}
 	
 	/* Get volume, or cellkind of the cell with type (identity) t */ 
-	getVolume : function( t ){
+	getVolume( t ){
 		return this.cellvolume[t]
-	},
-	cellKind : function( t ){
+	}
+	cellKind( t ){
 		return this.t2k[ t ]
-	},
+	}
 
 	/* Assign the cell with type (identity) t to kind k.*/
-	setCellKind : function( t, k ){
+	setCellKind( t, k ){
 		this.t2k[ t ] = k
-	},
+	}
 	
 	/* ------------- GRID HELPER FUNCTIONS --------------- */
 
 
 	/* 	A mod function with sane behaviour for negative numbers. 
 		Use to correctly link grid borders if TORUS = true. */
-	fmodx : function( x ) {
+	fmodx( x ) {
 		/*x = x % this.field_size.x
 		if( x > 0 ) return x
 		return ( x + this.field_size.x ) % this.field_size.x*/
 		return x
-	},
-	fmody : function( x ) {
+	}
+	fmody( x ) {
 		/*x = x % this.field_size.y
 		if( x > 0 ) return x
 		return ( x + this.field_size.y ) % this.field_size.y*/
 		return x
-	},
-	fmodz : function( x ) {
+	}
+	fmodz( x ) {
 		/*x = x % this.field_size.z
 		if( x > 0 ) return x
 		return ( x + this.field_size.z ) % this.field_size.z*/
 		return x
-	},	
+	}	
 
 
 	/* 	Convert pixel coordinates to unique pixel ID numbers and back.
 		Depending on this.ndim, the 2D or 3D version will be used by the 
 		wrapper functions p2i and i2p. Use binary encoding for speed. */
-	p2i3D : function( p ){
+	p2i3D ( p ){
 		return ( this.fmodx( p[0] ) << ( this.Z_BITS + this.Y_BITS ) ) + 
 			( this.fmody( p[1] ) << this.Z_BITS ) + 
 			this.fmodz( p[2] )
-	},
-	i2p3D : function( i ){
+	}
+	i2p3D ( i ){
 		return [i >> (this.Y_BITS + this.Z_BITS), ( i >> this.Z_BITS ) & this.Y_MASK, i & this.Z_MASK ]
-	},
-	p2i2D : function( p ){
+	}
+	p2i2D ( p ){
 		return ( this.fmodx( p[0] ) << this.Y_BITS ) + this.fmody( p[1] )
-	},
-	i2p2D : function( i ){
+	}
+	i2p2D ( i ){
 		return [i >> this.Y_BITS, i & this.Y_MASK]
-	},
+	}
 	
 	
-	/*	Return array of coordinates of neighbor pixels of the pixel at 
-		coordinates p. The separate 2D and 3D functions are called by
-		the wrapper function neigh, depending on this.ndim.
+	/*	Return array of indices of neighbor pixels of the pixel at 
+		index i. The separate 2D and 3D functions are called by
+		the wrapper function neighi, depending on this.ndim.
 
-		! Note: these functions are no longer used (replaced by neighi2D and
-			neighi3D below, which use pixel index instead of coordinates for speed).
-	
-	neigh2D : function( p ){
-		// compute neighbor x and y coordinates using fmod to allow linked
-		// grid borders.
-		var xr = this.fmodx( p[0] + 1 )
-		var xl = this.fmodx( p[0] - 1 )
-		var yl = this.fmody( p[1] - 1 )
-		var yr = this.fmody( p[1] + 1 )
-		var z = this.fmodz( p[2] )
-		// return an array with all neighbors
-		return [ 
-			[xl,yl,z], 	[p[0],yl,z],	[xr,yl,z],
-			[xl,p[1],z],			[xr,p[1],z],
-			[xl,yr,z],	[p[0],yr,z],	[xr,yr,z]
-		]
-	},
-	neigh3D : function( p ){
-		// compute neighbor x and y coordinates using fmod to allow linked
-		// grid borders.
-		var xr = this.fmodx( p[0] + 1 )
-		var xl = this.fmodx( p[0] - 1 )
-		var yl = this.fmody( p[1] - 1 )
-		var yr = this.fmody( p[1] + 1 )
-		var zl = this.fmodz( p[2] - 1 )
-		var zr = this.fmodz( p[2] + 1 )
-		// return an array with all neighbors
-		return [
-			[xl,yl,p[2]],   [xl,yl,zl], 	[xl,yl,zr],
-			[xl,p[1],p[2]], [xl,p[1],zl], 	[xl,p[1],zr],
-			[xl,yr,p[2]],   [xl,yr,zl], 	[xl,yr,zr],
-		
-			[p[0],yl,p[2]], [p[0],yl,zl], 	[p[0],yl,zr],
-			[p[0],p[1],zl],			[p[0],p[1],zr],
-			[p[0],yr,p[2]], [p[0],yr,zl], 	[p[0],yr,zr],
-		
-			[xr,yl,p[2]],   [xr,yl,zl], 	[xr,yl,zr],
-			[xr,p[1],p[2]], [xr,p[1],zl], 	[xr,p[1],zr],
-			[xr,yr,p[2]],   [xr,yr,zl], 	[xr,yr,zr]
-		]
-	},
 	*/
-	neighi2D : function( i ){
+	neighi2D( i ){
 		return [
-			i-1, i+1,  
-			i+this.dy+1, i+this.dy, i+this.dy-1,
-			i-this.dy+1, i-this.dy, i-this.dy-1 ]
-	},
-	neighi3D : function( i ){
-		var dy = this.dy
-		var dz = this.dz
+			i-this.dy-1, i-1, i+this.dy-1,
+			i-this.dy,i+this.dy,
+			i-this.dy +1, i+1, i+this.dy+1 ]
+	}
+	neighi3D( i ){
+		const dy = this.dy
+		const dz = this.dz
 		return[
-			i-1-dy+dz,	i -dy +dz,	i+1 -dy +dz,
-			i-1+dz,		i +dz,		i+1 +dz,
-			i-1+dy+dz,	i +dy +dz,	i+1 +dy +dz,
-
-			i-1-dy,		i-dy,		i+1-dy,
-			i-1,				i+1,
-			i-1+dy,		i+dy,		i+1+dy,
-
-			i-1-dy-dz,	i-dy-dz,	i+1-dy-dz,
-			i-1-dz,		i-dz,		i+1 -dz,
-			i-1+dy-dz,	i+dy-dz,	i+1+dy-dz
-		]
-	},
+		
+			i-1-dy-dz, i-1-dz, i-1+dy-dz,
+			i-dy-dz, i-dz, i+dy-dz,
+			i+1-dy-dz, i+1-dz, i+1+dy-dz,
+			
+			i-1-dy, i-1, i-1+dy,
+			i-dy,		i+dy,
+			i+1-dy, i+1, i+1+dy,
+			
+			i-1-dy+dz, i-1+dz, i-1+dy+dz,
+			i-dy+dz, i+dz, i+dy+dz, 
+			i+1-dy+dz, i+1+dz, i+1+dy+dz ]	
+	}
 
 
 
@@ -295,28 +257,32 @@ CPM.prototype = {
 		neighC2D does not. The current implementation uses only neighC2D, called by the
 		wrapper neighC if ndim = 2.
 	*/
-	neighC2D : {
-		0 : [1,3],
-		1 : [0,2,8],
-		2 : [1,4],
-		3 : [0,5,8],
-		4 : [2,7,8],
-		5 : [3,6],
-		6 : [5,7,8],
-		7 : [4,6],
-		8 : [1,3,4,6]
-	},
-	neighC2Da : {
-		0 : [1,3,8], 
-		1 : [0,2,3,4,8], 
-		2 : [1,4,8], 
-		3 : [0,1,5,6,8], 
-		4 : [1,2,6,7,8], 
-		5 : [3,6,8],
-		6 : [3,4,5,7,8], 
-		7 : [4,6,8],  
-		8 : [0,1,2,3,4,5,6,7]
-	},
+	neighC2D() {
+		return {
+			0 : [1,3],
+			1 : [0,2,8],
+			2 : [1,4],
+			3 : [0,5,8],
+			4 : [2,7,8],
+			5 : [3,6],
+			6 : [5,7,8],
+			7 : [4,6],
+			8 : [1,3,4,6] 
+		}
+	}
+	neighC2Da(){
+		return {
+			0 : [1,3,8], 
+			1 : [0,2,3,4,8], 
+			2 : [1,4,8], 
+			3 : [0,1,5,6,8], 
+			4 : [1,2,6,7,8], 
+			5 : [3,6,8],
+			6 : [3,4,5,7,8], 
+			7 : [4,6,8],  
+			8 : [0,1,2,3,4,5,6,7]
+		}
+	}
 	/* 
 		The following functions hardcode the neighbors of pixels in a given 3D neighborhood,
 		by id number. Consider a local 3D region of 3*9 pixels with the following ID numbers:
@@ -339,112 +305,127 @@ CPM.prototype = {
 		their neighbors (values). Considers only non-diagonal neighbors. Called by the
 		wrapper neighC if ndim = 3.
 	*/	
-	neighC3D : {
-		0 : [1,3,9],			//3 corner ( 2 + 1 ) : 2 from same layer, 1 from layer below
-		1 : [0,2,4,10],			//4 border ( 3 + 1 )
-		2 : [1,5,11],			//3 corner ( 2 + 1 )
-		3 : [0,4,6,12],			//4 border ( 3 + 1 )
-		4 : [1,3,5,7,13],		//5 center ( 4 + 1 )
-		5 : [2,4,8,14],			//4 border ( 3 + 1 )
-		6 : [3,7,15],			//3 corner ( 2 + 1 )
-		7 : [4,6,8,16],			//4 border ( 3 + 1 )
-		8 : [5,7,17],			//3 corner ( 2 + 1 )
+	neighC3D() {
 		
-		9 : [0,10,12,18],		//4 corner ( 2 + 1 + 1 ) : 2 same layer, 1 upper, 1 lower
-		10 : [1,9,13,11,19],	//5 border ( 3 + 1 + 1 )
-		11 : [2,10,14,20],		//4 corner ( 2 + 1 + 1 )
-		12 : [3,9,13,15,21],	//5 border ( 3 + 1 + 1 )
-		13 : [4,10,12,14,16,22],//6 center ( 4 + 1 + 1 )
-		14 : [5,11,13,17,23],	//5 border ( 3 + 1 + 1 )
-		15 : [6,12,16,24],		//4 corner ( 3 + 1 + 1 )
-		16 : [7,13,15,17,25],	//5 border ( 3 + 1 + 1 )
-		17 : [8,14,16,26],		//4 corner ( 2 + 1 + 1 )
+		const N = {
+			0 : [1,3,9],			//3 corner ( 2 + 1 ) : 2 from same layer, 1 from layer below
+			1 : [0,2,4,10],			//4 border ( 3 + 1 )
+			2 : [1,5,11],			//3 corner ( 2 + 1 )
+			3 : [0,4,6,12],			//4 border ( 3 + 1 )
+			4 : [1,3,5,7,26],		//5 center ( 4 + 1 )
+			5 : [2,4,8,13],			//4 border ( 3 + 1 )
+			6 : [3,7,14],			//3 corner ( 2 + 1 )
+			7 : [4,6,8,15],			//4 border ( 3 + 1 )
+			8 : [5,7,16],			//3 corner ( 2 + 1 )
 		
-		18 : [11,19,21],		//3 corner ( 2 + 1 ) : 2 same layer, 1 layer above
-		19 : [10,18,20,22],		//4 border ( 3 + 1 )
-		20 : [11,19,23],		//3 corner ( 2 + 1 )
-		21 : [12,18,22,24],		//4 border ( 3 + 1 )
-		22 : [13,19,21,23,25],	//5 center ( 4 + 1 )
-		23 : [14,20,22,26],		//4 border ( 3 + 1 )
-		24 : [15,21,25], 		//3 corner ( 2 + 1 )
-		25 : [16,22,24,26],		//4 border ( 3 + 1 )
-		26 : [17,23,25]			//3 corner ( 2 + 1 )
-	},
+			9 : [0,10,12,17],		//4 corner ( 2 + 1 + 1 ) : 2 same layer, 1 upper, 1 lower
+			10 : [1,9,26,11,18],	//5 border ( 3 + 1 + 1 )
+			11 : [2,10,13,19],		//4 corner ( 2 + 1 + 1 )
+			12 : [3,9,26,14,20],	//5 border ( 3 + 1 + 1 )
+			26 : [4,10,12,13,15,21],//6 center ( 4 + 1 + 1 )
+			13 : [5,11,26,16,22],	//5 border ( 3 + 1 + 1 )
+			14 : [6,12,15,23],		//4 corner ( 3 + 1 + 1 )
+			15 : [7,26,14,16,24],	//5 border ( 3 + 1 + 1 )
+			16 : [8,13,15,25],		//4 corner ( 2 + 1 + 1 )
+		
+			17 : [11,18,20],		//3 corner ( 2 + 1 ) : 2 same layer, 1 layer above
+			18 : [10,17,19,21],		//4 border ( 3 + 1 )
+			19 : [11,18,22],		//3 corner ( 2 + 1 )
+			20 : [12,17,21,23],		//4 border ( 3 + 1 )
+			21 : [26,18,20,22,24],	//5 center ( 4 + 1 )
+			22 : [13,19,21,25],		//4 border ( 3 + 1 )
+			23 : [14,20,24], 		//3 corner ( 2 + 1 )
+			24 : [15,21,23,25],		//4 border ( 3 + 1 )
+			25 : [16,22,24]			//3 corner ( 2 + 1 )
+		}
+		return N
+	}
 
 	
 
 	/* ------------- MATH HELPER FUNCTIONS --------------- */
 
 	/* Random integer number between incl_min and incl_max */
-	ran : function(incl_min, incl_max) {
+	ran (incl_min, incl_max) {
 		return Math.floor(Math.random() * (1.0 + incl_max - incl_min)) + incl_min
-	},
+	}
 	/* dot product */
-	dot : function( p1, p2 ){
-		var r = 0., i = 0
+	dot ( p1, p2 ){
+		let r = 0., i = 0
 		for( ; i < p1.length ; i ++ ){
 			r += p1[i]*p2[i]
 		}
 		return r
-	},
-	/*  To bias a copy attempt p1->p2 in the direction of target point pt.
-	Vector p1 -> p2 is the direction of the copy attempt, 
-	Vector p1 -> pt is the preferred direction. Then this function returns the cosine
-	of the angle alpha between these two vectors. This cosine is 1 if the angle between
-	copy attempt direction and preferred direction is 0 (when directions are the same), 
-	-1 if the angle is 180 (when directions are opposite), and 0 when directions are
-	perpendicular. */
-	pointAttractor : function( p1, p2, pt ){
-		var r = 0., i, norm1 = 0, norm2 = 0, d1=0., d2=0.
-		for( i=0 ; i < p1.length ; i ++ ){
-			d1 = pt[i]-p1[i]; d2 = p2[i]-p1[i]
-			r += d1 * d2
-			norm1 += d1*d1
-			norm2 += d2*d2
-		}
-		return r/Math.sqrt(norm1)/Math.sqrt(norm2)
-	},
+	}
 	
 	
 	/* ------------- COMPUTING THE HAMILTONIAN --------------- */
 
+
+	/* ======= ADHESION ======= */
+
 	/*  Returns the Hamiltonian around pixel p, which has ID (type) tp (surrounding pixels'
 	 *  types are queried). This Hamiltonian only contains the neighbor adhesion terms.
 	 */
-	H : function( i, tp ){
+	H( i, tp ){
 
-		var r = 0, tn, N = this.neighi( i )
+		let r = 0, tn
+		const N = this.neighi( i )
 
 		// Loop over pixel neighbors
-		for( var j = 0 ; j < N.length ; j ++ ){
+		for( let j = 0 ; j < N.length ; j ++ ){
 			tn = this.pixti( N[j] )
 			if( tn != tp ) r += this.J( tn, tp )
 		}
 
 		return r
-	},
+	}
+	
+	deltaHadhesion ( sourcei, targeti, src_type, tgt_type ){
+		return this.H( targeti, src_type ) - this.H( targeti, tgt_type )
+	}
+	
 
+
+	/* ======= VOLUME ======= */
 
 	/* The volume constraint term of the Hamiltonian for the cell with id t.
 	   Use vgain=0 for energy of current volume, vgain=1 for energy if cell gains
 	   a pixel, and vgain = -1 for energy if cell loses a pixel. 
 	*/
-	volconstraint : function( vgain, t ){
+	volconstraint ( vgain, t ){
 
 		// the background "cell" has no volume constraint.
 		if( t == 0 ) return 0	
 
-		var vdiff = this.par("V",t) - (this.cellvolume[t] + vgain)
+		const vdiff = this.par("V",t) - (this.cellvolume[t] + vgain)
+		
 		return this.par("LAMBDA_V",t)*vdiff*vdiff
-	},
+	}
+	
+	deltaHvolume ( sourcei, targeti, src_type, tgt_type ){
+
+		// volume gain of src cell
+		let deltaH = this.volconstraint( 1, src_type ) - 
+			this.volconstraint( 0, src_type )
+		// volume loss of tgt cell
+		deltaH += this.volconstraint( -1, tgt_type ) - 
+			this.volconstraint( 0, tgt_type )
+
+		return deltaH
+
+	}
+	
+	
+	/* ======= PERIMETER ======= */
 
 	/* The perimeter constraint term of the Hamiltonian. Returns the change in
 	   perimeter energy if the pixel at coordinates p is changed from cell "oldt"
 	   into "newt".
 	*/
-	perconstrainti : function( pixid, oldt, newt ){
-		var N = this.neighi( pixid ), perim_before = {},
-			perim_after = {}, i, t, ta, r=0, Pup = {}
+	perconstrainti ( pixid, oldt, newt ){
+		const N = this.neighi( pixid )
+		let perim_before = {}, perim_after = {}
 		
 		/* Loop over the local neighborhood and track perimeter of the old 
 		and new cell (oldt, newt) before/after update. Note that perimeter
@@ -452,10 +433,10 @@ CPM.prototype = {
 		perim_before[oldt]=0; perim_before[newt]=0
 		perim_after[oldt]=0; perim_after[newt]=0
 
-		for( i = 0 ; i < N.length ; i ++ ){
+		for( let i = 0 ; i < N.length ; i ++ ){
 
 			// Type of the current neighbor
-			t = this.pixti( N[i] )
+			const t = this.pixti( N[i] )
 
 			if( t != oldt ){
 				perim_before[oldt] ++
@@ -468,12 +449,13 @@ CPM.prototype = {
 		}
 		// Compare perimeter before and after to evaluate the change in perimeter.
 		// Use this to compute the change in perimeter energy.
-		ta = Object.keys( perim_after )
-		for( i = 0 ; i < ta.length ; i ++ ){
+		const ta = Object.keys( perim_after )
+		let r = 0, Pup = {}
+		for( let i = 0 ; i < ta.length ; i ++ ){
 			if( ta[i] > 0 ){
 				Pup[ta[i]] = perim_after[ta[i]] - perim_before[ta[i]]
-				var Pt = this.par("P",ta[i]), l = this.par("LAMBDA_P",ta[i])
-				t = this.cellperimeter[ta[i]]+Pup[ta[i]] - Pt
+				const Pt = this.par("P",ta[i]), l = this.par("LAMBDA_P",ta[i])
+				let t = this.cellperimeter[ta[i]]+Pup[ta[i]] - Pt
 				r += l*t*t
 				t = this.cellperimeter[ta[i]] - Pt
 				r -= l*t*t
@@ -483,30 +465,39 @@ CPM.prototype = {
 		// output variables: r is the change in perimeter energy, Pup the
 		// perimeter updates
 		return { r:r, Pup:Pup }
-	},
-
+	}
+	
+	deltaHperimeter ( sourcei, targeti, src_type, tgt_type ){
+		return this.perconstrainti( targeti, tgt_type, src_type )
+	}
+	
+	
+	/* ======= ACT MODEL ======= */
+	
 	/* Current activity (under the Act model) of the pixel with ID i. */
-	pxact : function( i ){
-		var age = (this.time - this.cellpixelsbirth[i]), 
+	pxact ( i ){
+		const age = (this.time - this.cellpixelsbirth[i]), 
 			actmax = this.par("MAX_ACT",this.cellpixelstype[i])
+			
 		return (age > actmax) ? 0 : actmax-age
-	},
+	}
 	/* Act model : compute local activity values within cell around pixel i.
 	 * Depending on settings in conf, this is an arithmetic (activityAtArith)
 	 * or geometric (activityAtGeom) mean of the activities of the neighbors
 	 * of pixel i.
 	 */
-	activityAtArith : function( i ){
-		var t = this.pixti( i )
+	activityAtArith( i ){
+		const t = this.pixti( i )
 		
 		// no activity for background/stroma
 		if( t <= 0 ){ return 0 }
-		var tn, nN=1, N = this.neighi(i), r = this.pxact(i) 
-		var has_stroma_neighbour = false
+		
+		const N = this.neighi(i)
+		let r = this.pxact(i), has_stroma_neighbour = false, nN = 1
 		
 		// loop over neighbor pixels
-		for( var j = 0 ; j < N.length ; j ++ ){ 
-			tn = this.pixti(N[j]) 
+		for( let j = 0 ; j < N.length ; j ++ ){ 
+			const tn = this.pixti(N[j]) 
 			
 			// a neighbor only contributes if it belongs to the same cell
 			if( tn == t ){
@@ -524,20 +515,18 @@ CPM.prototype = {
 			r *= this.par("FRC_BOOST",t)
 		}
 		return r/nN
-	},
-	activityAtGeom : function( i ){
-		var t = this.pixti( i ), tn
+	}
+	activityAtGeom ( i ){
+		const t = this.pixti( i )
 
 		// no activity for background/stroma
 		if( t <= 0 ){ return 0 }
-		var N = this.neighi( i )
-		var nN = 1
-		var r = this.pxact( i )
-		var has_stroma_neighbour = false
+		const N = this.neighi( i )
+		let nN = 1, r = this.pxact( i ), has_stroma_neighbour = false
 
 		// loop over neighbor pixels
-		for( var j = 0 ; j < N.length ; j ++ ){ 
-			tn = this.pixti(N[j]) 
+		for( let j = 0 ; j < N.length ; j ++ ){ 
+			const tn = this.pixti(N[j]) 
 
 			// a neighbor only contributes if it belongs to the same cell
 			if( tn == t ){
@@ -556,60 +545,155 @@ CPM.prototype = {
 			r *= this.par("FRC_BOOST",1)
 		}
 		return Math.pow(r,1/nN)
-	},
+	}
+	
+	deltaHactmodel ( sourcei, targeti, src_type, tgt_type ){
 
-	/* Connectivity constraint. 
+		let deltaH = 0, maxact, lambdaact
+
+		// use parameters for the source cell, unless that is the background.
+		// In that case, use parameters of the target cell.
+		if( src_type != 0 ){
+			maxact = this.par("MAX_ACT",src_type)
+			lambdaact = this.par("LAMBDA_ACT",src_type)
+		} else {
+			// special case: punishment for a copy attempt from background into
+			// an active cell. This effectively means that the active cell retracts,
+			// which is different from one cell pushing into another (active) cell.
+			maxact = this.par("MAX_ACT",tgt_type)
+			lambdaact = this.par("LAMBDA_ACT",tgt_type)
+		}
+		if( maxact > 0 ){
+			deltaH += lambdaact*(this.activityAt( targeti ) - this.activityAt( sourcei ))/maxact
+		}
+		return deltaH
+	}
+	
+	/* ======= CONNECTIVITY ======= */
+
+	/* Connectivity constraint. Checks the number of connected components 
+	of type t in neighbourhood N of a pixel with type tp.
 	*/
-	nrConnectedComponents : function( N, t, tp ){
-		var r = 0, i, j, v, visited = [], stack = [], _this=this
-		var Nt = function( k ){
+	nrConnectedComponents ( N, t, tp ){
+		let r = 0, v, visited = [] 
+		const nc = this.neighC(), _this=this
+		
+		const Nt = function( k){
 			if( k < N.length ){ 
-				var t = _this.pixti( N[k] ) 
+				const t = _this.pixti( N[k] ) 
 				return t >= 0 ? t : 0
 			}
+			// if k is equal to N.length, we mean the middle pixel whose
+			// neighbourhood we are looking at (and whose type is tp).
 			return tp
 		}
-		for( i = 0 ; i < N.length+1 ; i ++ ){
-			stack = []
+		// Loop over the pixels in the neighbourhood N.
+		// Add one extra pixel (the pixel whose neighbourhood we are looking at).
+		// For each pixel, find all other pixels in the connected component and
+		// store them as "visited". Only start a new connected component for 
+		// pixels that were not previously visited.
+		for( let i = 0 ; i < N.length+1 ; i ++ ){
+			let stack = []
+			// we only start at this pixel if it wasn't part of another connected
+			// component (visited), and if it is of type t.
 			if( !visited[i] && ( Nt(i) == t ) ){
+				// this is a new connected component
 				r ++
+				// depth first search algorithm to find all pixels in N
+				// that are part of this component.
 				stack.push( i )
 				while( stack.length > 0 ){
 					v = stack.pop()
 					visited[v] = true
-					for( j = 0 ; j < this.neighC[v].length ; j ++ ){
-						if( !visited[this.neighC[v][j]] 
-							&& ( Nt(this.neighC[v][j]) == t ) ){
-							stack.push( this.neighC[v][j] )
+					const ncv = nc[v]
+					for( let j = 0 ; j < ncv.length ; j ++ ){
+					// loop over the neighbours within N (in this.neighC(v)[j])
+					// add them to the stack if they haven't been visited yet.
+						if( !visited[ncv[j]] 
+							&& ( Nt(ncv[j] ) == t ) ){
+							stack.push( ncv[j] )
 						}
 					}
 				}
 			}
 		}
 		return r
-	},
-	/* Evaluate the change in connectivity energy associated with changing pixel p
-		from cellid told to tnew.
+	}
+	
+	/* Evaluate the change in connectivity energy associated with changing pixel targeti
+		from cellid src_type to tgt_type
 	*/
-	connectivityConstraint : function( i, told, tnew ){
-		var N, cost = this.par("LAMBDA_CONNECTIVITY",told) 
-		if( cost > 0 ){
-			N = this.neighi( i )
-			if( this.nrConnectedComponents( N, told, told )
-				!= this.nrConnectedComponents( N, told, tnew ) ){
-				return cost
+	deltaHconnectivity ( sourcei, targeti, src_type, tgt_type ){
+		
+		// For the connectivity constraint, we look at connected components
+		// in the neighbourhood of the target pixel (which might change type).
+		const N = this.neighi( targeti )
+		let totalcost = 0
+		
+		// Changes in connected components of the cell src_type when the pixel at
+		// targeti changes from tgt_type to src_type
+		let cost1 = this.par("LAMBDA_CONNECTIVITY",tgt_type)
+		if( cost1 > 0 ){
+			if( this.nrConnectedComponents( N, tgt_type, src_type )
+				!= this.nrConnectedComponents( N, tgt_type, tgt_type ) ){
+				totalcost += cost1
+				
 			}
 		}
-		cost = this.par("LAMBDA_CONNECTIVITY",tnew) 
-		if( cost > 0 ){
-			if( !N ) N = this.neighi( i )
-			if( this.nrConnectedComponents( N, tnew, told )
-				!= this.nrConnectedComponents( N, tnew, tnew ) ){
-				return cost
+		// Changes in connected components of the cell tgt_type when the pixel at 
+		// targeti changes from tgt_type to src_type
+		let cost2 = this.par("LAMBDA_CONNECTIVITY",src_type) 
+		if( cost2 > 0 ){
+			if( this.nrConnectedComponents( N, src_type, src_type )
+				!= this.nrConnectedComponents( N, src_type, tgt_type ) ){
+				totalcost += cost2
 			}
 		}
-		return 0
-	},
+		return totalcost
+	}
+	
+	// invasiveness. If there is a celltype a that prefers to invade
+	// pixels of type b. Currently not used.
+	deltaHinvasiveness ( sourcei, targeti, src_type, tgt_type ){
+		var deltaH = 0	
+		if( tgt_type != 0 && src_type != 0 && this.conf.INV ){
+			deltaH += this.par( "INV", tgt_type, src_type )
+		}
+		return -deltaH
+	}
+	
+	// returns both change in hamiltonian and perimeter
+	deltaH ( sourcei, targeti, src_type, tgt_type ){
+
+		
+		const terms = this.terms
+		let dHlog = {}, per, currentterm
+	
+		let r = 0.0
+		for( let i = 0 ; i < terms.length ; i++ ){
+			currentterm = this["deltaH"+terms[i]].call( this,sourcei,targeti,src_type,tgt_type )
+			if( terms[i]=="perimeter"){
+				r+=currentterm.r
+				per = currentterm
+				dHlog[terms[i]] = currentterm.r
+			} else {
+				r += currentterm
+				dHlog[terms[i]] = currentterm
+			}
+		
+		}
+
+		if( ( this.logterms || 0 ) && this.time % 100 == 0 ){
+			// eslint-disable-next-line no-console
+			console.log( dHlog )
+		}
+
+		return ({ dH: r, per: per })
+
+	}
+	
+	
+	
 	
 	/* ------------- COPY ATTEMPTS --------------- */
 
@@ -619,9 +703,10 @@ CPM.prototype = {
 		3) With a probability depending on this change, decline or accept the 
 		   copy attempt and update the grid accordingly. 
 	*/
-	monteCarloStep : function(){
+	
+	monteCarloStep (){
 
-		var delta_t = 0.0, p1i, p2i, src_type, tgt_type, N, per, maxact, lambdaact
+		let delta_t = 0.0
 
 		// this loop tracks the number of copy attempts until one MCS is completed.
 		while( delta_t < 1.0 ){
@@ -630,6 +715,8 @@ CPM.prototype = {
 			// randomly draw another border pixel.
 			delta_t += 1./(this.bgborderpixels.length + this.cellborderpixels.length)
 
+
+			let p1i
 			// Randomly sample one of the CPM border pixels (the "source" (src)),
 			// and one of its neighbors (the "target" (tgt)).
 			if( this.ran( 0, this.bgborderpixels.length + this.cellborderpixels.length )
@@ -638,78 +725,40 @@ CPM.prototype = {
 			} else {
 				p1i = this.cellborderpixels.sample()
 			}
-			
-			N = this.neighi( p1i )
-			p2i = N[this.ran(0,N.length-1)]
-			
-			src_type = this.pixti( p1i )
-			tgt_type = this.pixti( p2i )
+		
+			const N = this.neighi( p1i )
+			const p2i = N[this.ran(0,N.length-1)]
+		
+			const src_type = this.pixti( p1i )
+			const tgt_type = this.pixti( p2i )
 
 			// only compute the Hamiltonian if source and target belong to a different cell,
 			// and do not allow a copy attempt into the stroma. Only continue if the copy attempt
 			// would result in a viable cell.
 			if( tgt_type >= 0 && src_type != tgt_type ){
 
-				// change in Hamiltonian: basic Hamiltonian
-				var deltaH = this.H( p2i, src_type ) - this.H( p2i, tgt_type )
-				
-				// change in Hamiltonian: volume gain of src cell
-				deltaH += this.volconstraint( 1, src_type ) - 
-					this.volconstraint( 0, src_type )
-				// change in Hamiltonian: volume loss of tgt cell
-				deltaH += this.volconstraint( -1, tgt_type ) - 
-					this.volconstraint( 0, tgt_type )
+				const hamiltonian = this.deltaH( p1i, p2i, src_type, tgt_type )
 
-				// change in Hamiltonian: perimeter constraint
-				per = this.perconstrainti( p2i, tgt_type, src_type )
-				deltaH += per.r
-			
-				// invasiveness. If there is a celltype a that prefers to invade
-				// pixels of type b. Currently not used.
-				if( tgt_type != 0 && src_type != 0 && this.conf.INV ){
-					deltaH -= this.par( "INV", tgt_type, src_type )
-				}	
-
-				// change in Hamiltonian: Act model.
-				// use parameters for the source cell, unless that is the background.
-				// In that case, use parameters of the target cell.
-				if( src_type != 0 ){
-					maxact = this.par("MAX_ACT",src_type)
-					lambdaact = this.par("LAMBDA_ACT",src_type)
-				} else {
-					// special case: punishment for a copy attempt from background into
-					// an active cell. This effectively means that the active cell retracts,
-					// which is different from one cell pushing into another (active) cell.
-					maxact = this.par("MAX_ACT",tgt_type)
-					lambdaact = this.par("LAMBDA_ACT",tgt_type)
-				}
-				if( maxact > 0 ){
-					deltaH += lambdaact
-						*(this.activityAt( p2i ) - 
-						this.activityAt( p1i ))/maxact
-				}
-			
-				// change in Hamiltonian: connectivity constraint
-				deltaH += this.connectivityConstraint( p2i, tgt_type, src_type ) 
-	
-				// probabilistic success of copy attempt
-				if( this.docopy( deltaH ) ){
-					this.setpixi( p2i, src_type, per.Pup )
+				// probabilistic success of copy attempt        
+				if( this.docopy( hamiltonian.dH ) ){
+					this.setpixi( p2i, src_type, hamiltonian.per.Pup )
 				}
 			}
+
 		}
-		this.time ++	// update time with one MCS.
-	},
+
+		this.time++ // update time with one MCS.
+	}	
 
 	/* Determine whether copy attempt will succeed depending on deltaH (stochastic). */
-	docopy :  function( deltaH ){
+	docopy ( deltaH ){
 		if( deltaH < 0 ) return true
 		return Math.random() < Math.exp( -deltaH / this.conf.T )
-	},
+	}
 	/* Change the pixel at position p (coordinates) into cellid t. 
 	Update cell perimeters with Pup (optional parameter).*/
-	setpixi :  function( i, t, Pup ){
-		var t_old = this.cellpixelstype[i]
+	setpixi ( i, t, Pup ){
+		const t_old = this.cellpixelstype[i]
 
 		// If Pup not specified, compute it here.
 		if( !Pup ){
@@ -741,13 +790,13 @@ CPM.prototype = {
 		// update cellperimeters and border pixels.
 		this.updateperimeter( Pup )
 		this.updateborderneari( i )
-	},
-	setpix : function( p, t, Pup ){
-		return this.setpixi( this.p2i(p), t, Pup )
-	},
+	}
+	setpix ( p, t, Pup ){
+		this.setpixi( this.p2i(p), t, Pup )
+	}
 	/* Change pixel at coordinates p/index i into background (t=0) */
-	delpixi : function( i ){
-		var t = this.cellpixelstype[i]
+	delpixi ( i ){
+		const t = this.cellpixelstype[i]
 
 		// Reduce cell volume.
 		this.cellvolume[t] --
@@ -763,39 +812,38 @@ CPM.prototype = {
 			delete this.t2k[t]
 		}
 
-	},
-	delpix : function( p ){
-		return this.delpixi( this.p2i(p) )
-	},
+	}
+	delpix ( p ){
+		this.delpixi( this.p2i(p) )
+	}
 	/* Update each cell's perimeter after a successful copy attempt. */
-	updateperimeter : function( Pup ){
-		var i, ta = Object.keys( Pup )
-		for( i = 0 ; i < ta.length ; i ++ ){
+	updateperimeter ( Pup ){
+		const ta = Object.keys( Pup )
+		for( let i = 0 ; i < ta.length ; i ++ ){
 			this.cellperimeter[ta[i]] += Pup[ta[i]]
 		}
-	},
+	}
 	/* Update border elements after a successful copy attempt. */
-	updateborderneari : function( i ){
-		var j, k, t, isborder, N
+	updateborderneari ( i ){
 
 		// neighborhood + pixel itself (in indices)
-		var Ni = this.neighi(i)
+		const Ni = this.neighi(i)
 		Ni.push(i)
 		
-		for( j = 0 ; j < Ni.length ; j ++ ){
+		for( let j = 0 ; j < Ni.length ; j ++ ){
 
 			i = Ni[j]
-			t = this.pixti( i )
+			const t = this.pixti( i )
 
 			// stroma pixels are not stored
 			if( t < 0 ) continue
-			isborder = false
+			let isborder = false
 
 			// loop over neighborhood of the current pixel.
 			// if the pixel has any neighbors belonging to a different cell,
 			// it is a border pixel.			
-			N = this.neighi( Ni[j] )
-			for( k = 0 ; k < N.length ; k ++ ){
+			const N = this.neighi( Ni[j] )
+			for( let k = 0 ; k < N.length ; k ++ ){
 				if( this.pixti( N[k] ) != t ){
 					isborder = true; break
 				}
@@ -821,42 +869,34 @@ CPM.prototype = {
 				}
 			}
 		}
-	},
+	}
 
 
 	/* ------------- MANIPULATING CELLS ON THE GRID --------------- */
 
-	newDice : function(){
-		return new DiceSet()
-	},
 
 	/* Initiate a new cellid for a cell of celltype "kind", and create elements
 	   for this cell in the relevant arrays (cellvolume, cellperimeter, t2k).*/
-	makeNewCellID : function( kind ){
-		var newid = ++ this.nr_cells
+	makeNewCellID ( kind ){
+		const newid = ++ this.nr_cells
 		this.cellvolume[newid] = 0
 		this.cellperimeter[newid] = 0
 		this.setCellKind( newid, kind )
 		return newid
-	},
+	}
 	/* Seed a new cell of celltype "kind" onto position "p".*/
-	seedCellAt : function( kind, p ){
-		var newid = this.makeNewCellID( kind )
-		var id = this.p2i( p )
+	seedCellAt ( kind, p ){
+		const newid = this.makeNewCellID( kind )
+		const id = this.p2i( p )
 		this.setpixi( id, newid )
 		return newid
-	},
+	}
 	/* Seed a new cell of celltype "kind" to a random position on the grid.
 		Opts: fixToStroma (only seed next to stroma),
 		brutal (allow seeding into other non-background cell),
 		avoid (do not allow brutal seeding into cell of type "avoid"). */
-	seedCell : function( kind, opts ){
-	
-		// N: max amount of trials, avoids infinite loops in degenerate
-		// situations
-		var N = 1000,  
-			p, stromapixels, Ns, t
-			
+	seedCell ( kind, opts ){
+		let N, p
 		// By default, seed a cell of kind 1, without any options.
 		if( arguments.length < 1 ){
 			kind = 1
@@ -865,7 +905,9 @@ CPM.prototype = {
 			opts = {}
 		}
 		if( !opts.fixToStroma ){
-			for( ; N>0 ; N-- ){
+			// N: max amount of trials, avoids infinite loops in degenerate
+			// situations
+			for( N = 1000; N>0 ; N-- ){
 				// random position on the grid
 				p = [this.ran( 0, this.field_size.x-1 ),
 					this.ran( 0, this.field_size.y-1 )]
@@ -874,7 +916,7 @@ CPM.prototype = {
 				} else {
 					p.push( 0 )
 				}
-				t = this.pixti( this.p2i( p ) )
+				const t = this.pixti( this.p2i( p ) )
 
 				// seeding successful if this position is background, or if
 				// the brutal option is on.
@@ -887,9 +929,9 @@ CPM.prototype = {
 			}
 		// if option fixToStroma
 		} else {
-			stromapixels = Object.keys( this.stromapixelstype )
-			Ns=stromapixels.length
-			for( ; N>0 ; N-- ){
+			const stromapixels = Object.keys( this.stromapixelstype )
+			const Ns=stromapixels.length
+			for( N = 1000; N>0 ; N-- ){
 				// Choose a random stroma pixel, and then randomly choose one of its
 				// neighbors.
 				p = this.i2p( this.neighi( stromapixels[this.ran(0,Ns-1)] )[
@@ -902,33 +944,27 @@ CPM.prototype = {
 		}
 		if( N == 0 ) return false
 		return this.seedCellAt( kind, p, opts )
-	},
+	}
 	/* Change the pixels defined by stromavoxels (array of coordinates p) into
 	   the special stromatype. */
-	addStroma : function( stromavoxels, stromatype ){
+	addStroma ( stromavoxels, stromatype ){
 		// the celltype used for stroma is default -1.
 		if( arguments.length < 2 ){
 			stromatype = -1
 		}
 		// store stromapixels in a special object. 
-		for( var i = 0 ; i < stromavoxels.length ; i ++ ){
+		for( let i = 0 ; i < stromavoxels.length ; i ++ ){
 			this.stromapixelstype[this.p2i( stromavoxels[i] )]=stromatype
 		}
-	},
+	}
 	// Adds a plane of stroma pixels at coord x/y/z (coded by 0,1,2) value [coordvalue],
 	// by letting the other coordinates range from their min value 0 to their max value.
-	addStromaPlane : function( stromavoxels, coord, coordvalue, stromatype ){
-		var x,y,z
-		var minc = [0,0,0]
-		var maxc = [this.field_size.x-1, this.field_size.y-1, this.field_size.z-1]
+	addStromaPlane ( stromavoxels, coord, coordvalue ){
+		let x,y,z
+		let minc = [0,0,0]
+		let maxc = [this.field_size.x-1, this.field_size.y-1, this.field_size.z-1]
 		minc[coord] = coordvalue
 		maxc[coord] = coordvalue
-
-
-		// the celltype used for stroma is default -1.
-		if( arguments.length < 4 ){
-			stromatype = -1
-		}
 
 		// For every coordinate x,y,z, loop over all possible values from min to max.
 		// one of these loops will have only one iteration because min = max = coordvalue.
@@ -945,13 +981,12 @@ CPM.prototype = {
 			}
 		}
 
-		
-		return stromavoxels;
-	},
+		return stromavoxels
+	}
 
-	addStromaBorder : function( stromatype ){
-		var stromavoxels = [], i
-		var x = this.field_size.x-1, y = this.field_size.y-1, z = this.field_size.z-1
+	addStromaBorder ( stromatype ){
+		let stromavoxels = []
+		const x = this.field_size.x-1, y = this.field_size.y-1, z = this.field_size.z-1
 
 		// the celltype used for stroma is default -1.
 		if( arguments.length < 1 ){
@@ -968,48 +1003,21 @@ CPM.prototype = {
 			stromavoxels = this.addStromaPlane( stromavoxels, 2, z, stromatype )
 		}
 
-
-
-
-		/*
-		// borders in x direction
-		for( i = 0 ; i <= x; i ++ ){
-			stromavoxels.push( [ i, 0, 0 ] )
-			stromavoxels.push( [ i, y-1, 0 ] )
-			stromavoxels.push( [ i, 0, z-1 ] )
-			stromavoxels.push( [ i, y-1, z-1 ] )
-		}
-		// borders in y direction
-		for( i = 0; i <= y; i++ ){
-			stromavoxels.push( [ 0, i, 0] )
-			stromavoxels.push( [ 0, i, z-1 ] )
-			stromavoxels.push( [ x-1, i, 0 ] )
-			stromavoxels.push( [ x-1, i, z-1 ] )
-		}
-		// borders in z direction
-		for( i = 0; i <= z; i++ ){
-			stromavoxels.push( [ 0, 0, i ] )
-			stromavoxels.push( [ x-1, 0, i ] )
-			stromavoxels.push( [ 0, y-1, i ] )
-			stromavoxels.push( [ x-1, y-1, i ] )
-		}
-		*/
-		//console.log( stromavoxels.length )
 		this.addStroma( stromavoxels, stromatype )
-	},
+	}
 
 
 	/** Checks whether position p (given as array) is adjacent to any pixel of type
 	t */
-	isAdjacentToType : function( p, t ){
-		var i = this.p2i(p)
-		var N = this.neighi( i )
+	isAdjacentToType ( p, t ){
+		const i = this.p2i(p)
+		const N = this.neighi( i )
 		return N.map( function(pn){ return this.pixti(pn)==t } ).
 			reduce( function(xa,x){ return xa || x }, false ) 
-	},
-	countCells : function( kind ){
+	}
+	countCells ( kind ){
 		return this.t2k.reduce( function(xa,x){ return (x==kind) + xa } )
-	},
+	}
 
 }
 

--- a/src/CPM.js
+++ b/src/CPM.js
@@ -395,9 +395,9 @@ CPM.prototype = {
 	-1 if the angle is 180 (when directions are opposite), and 0 when directions are
 	perpendicular. */
 	pointAttractor : function( p1, p2, pt ){
-		var r = 0., i = 0, norm1 = 0, norm2 = 0, d1=0., d2=0.
-		for( ; i < p1.length ; i ++ ){
-			d1 = p1[i]-pt[i]; d2 = p2[i]-p1[i]
+		var r = 0., i, norm1 = 0, norm2 = 0, d1=0., d2=0.
+		for( i=0 ; i < p1.length ; i ++ ){
+			d1 = pt[i]-p1[i]; d2 = p2[i]-p1[i]
 			r += d1 * d2
 			norm1 += d1*d1
 			norm2 += d2*d2

--- a/src/CPMCanvas.js
+++ b/src/CPMCanvas.js
@@ -6,17 +6,26 @@ function CPMCanvas( C, options ){
 	this.zoom = (options && options.zoom) || 1
 
 	this.wrap = (options && options.wrap) || [0,0,0]
+	this.width = this.wrap[0]
+	this.height = this.wrap[1]
+
+	if( this.width == 0 || this.C.field_size.x < this.width ){
+		this.width = this.C.field_size.x
+	}
+	if( this.height == 0 || this.C.field_size.y < this.height ){
+		this.height = this.C.field_size.y
+	}
 
 	if( typeof document !== "undefined" ){
 		this.el = document.createElement("canvas")
-		this.el.width = C.field_size.x*this.zoom
-		this.el.height = C.field_size.y*this.zoom
+		this.el.width = this.width*this.zoom
+		this.el.height = this.height*this.zoom//C.field_size.y*this.zoom
 		var parent_element = (options && options.parentElement) || document.body
 		parent_element.appendChild( this.el )
 	} else {
 		var Canvas = require("canvas")
-		this.el = new Canvas( C.field_size.x*this.zoom,
-			C.field_size.y*this.zoom )
+		this.el = new Canvas( this.width*this.zoom,
+			this.height*this.zoom )
 		this.fs = require("fs")
 	}
 

--- a/src/CPMCanvas.js
+++ b/src/CPMCanvas.js
@@ -23,8 +23,8 @@ function CPMCanvas( C, options ){
 		var parent_element = (options && options.parentElement) || document.body
 		parent_element.appendChild( this.el )
 	} else {
-		var Canvas = require("canvas")
-		this.el = new Canvas( this.width*this.zoom,
+		const {createCanvas} = require("canvas")
+		this.el = createCanvas( this.width*this.zoom,
 			this.height*this.zoom )
 		this.fs = require("fs")
 	}

--- a/src/CPMCanvas.js
+++ b/src/CPMCanvas.js
@@ -5,6 +5,8 @@ function CPMCanvas( C, options ){
 	this.C = C
 	this.zoom = (options && options.zoom) || 1
 
+	this.wrap = (options && options.wrap) || [0,0,0]
+
 	if( typeof document !== "undefined" ){
 		this.el = document.createElement("canvas")
 		this.el.width = C.field_size.x*this.zoom
@@ -64,6 +66,16 @@ CPMCanvas.prototype = {
 		return this.ctx
 	},
 
+	i2p : function( i ){
+		var p = this.C.i2p( i ), dim
+		for( dim = 0; dim < p.length; dim++ ){
+			if( this.wrap[dim] != 0 ){
+				p[dim] = p[dim] % this.wrap[dim]
+			}
+		}
+		return p
+	},
+
 	/* DRAWING FUNCTIONS ---------------------- */
 
 	/* Use to draw the border of each cell on the grid in the color specified in "col"
@@ -71,7 +83,7 @@ CPMCanvas.prototype = {
 	outer pixels)*/
 	drawCellBorders : function( col ){
 		col = col || "000000"
-		var p, pc, pu, pd, pl, pr, i
+		var p, pc, pu, pd, pl, pr, i, pdraw
 		this.col( col )
 		this.ctx.fillStyle="#"+col
 
@@ -79,22 +91,23 @@ CPMCanvas.prototype = {
 		var cst =  this.C.cellborderpixels.elements
 		for( i = 0 ; i < cst.length ; i ++ ){
 			p = this.C.i2p( cst[i] )
+			pdraw = this.i2p( cst[i] )
 			pc = this.C.pixt( [p[0],p[1],0] )
 			pr = this.C.pixt( [p[0]+1,p[1],0] )
 			pl = this.C.pixt( [p[0]-1,p[1],0] )		
 			pd = this.C.pixt( [p[0],p[1]+1,0] )
 			pu = this.C.pixt( [p[0],p[1]-1,0] )
 			if( pc != pl  ){
-				this.pxdrawl( p )
+				this.pxdrawl( pdraw )
 			}
 			if( pc != pr ){
-				this.pxdrawr( p )
+				this.pxdrawr( pdraw )
 			}
 			if( pc != pd ){
-				this.pxdrawd( p )
+				this.pxdrawd( pdraw )
 			}
 			if( pc != pu ){
-				this.pxdrawu( p )
+				this.pxdrawu( pdraw )
 			}
 		}
 	},
@@ -124,7 +137,7 @@ CPMCanvas.prototype = {
 					} else {
 						this.col( tohex(2*a)+"FF00" )
 					} 
-					this.pxf( this.C.i2p( ii ) )
+					this.pxf( this.i2p( ii ) )
 				}
 			}
 		}
@@ -136,7 +149,7 @@ CPMCanvas.prototype = {
 		this.ctx.fillStyle="#"+col
 		var cst =  this.C.cellborderpixels.elements, i
 		for( i = 0 ; i < cst.length ; i ++ ){
-			this.pxf( this.C.i2p( cst[i] ) )
+			this.pxf( this.i2p( cst[i] ) )
 		}
 	},
 
@@ -150,7 +163,7 @@ CPMCanvas.prototype = {
 		var cst = Object.keys( this.C.cellpixelstype ), i
 		for( i = 0 ; i < cst.length ; i ++ ){
 			if( this.C.cellKind(this.C.cellpixelstype[cst[i]]) == kind ){
-				this.pxf( this.C.i2p( cst[i] ) )
+				this.pxf( this.i2p( cst[i] ) )
 			}
 		}
 	},
@@ -164,7 +177,7 @@ CPMCanvas.prototype = {
 		// pixel index of all stroma pixels.
 		var cst = Object.keys( this.C.stromapixelstype ), i
 		for( i = 0 ; i < cst.length ; i ++ ){
-			this.pxf( this.C.i2p( cst[i] ) )
+			this.pxf( this.i2p( cst[i] ) )
 		}
 	},
 

--- a/src/CPMStats.js
+++ b/src/CPMStats.js
@@ -312,7 +312,7 @@ CPMStats.prototype = {
 			// we only consider non-zero gradients for the order index
 			if( gn != 0 ){
 				for( d = 0; d < this.C.ndim; d++ ){
-					gradientsum[d] += g[d]/gn
+					gradientsum[d] += 100*g[d]/gn/cellindices.length
 				}
 			}
 		}
@@ -323,7 +323,7 @@ CPMStats.prototype = {
 		return orderindex	
 	},
 	getOrderIndices : function( ){
-		var cpi = this.cellpixelsi()
+		var cpi = this.cellborderpixelsi() //this.cellpixelsi()
 		var tx = Object.keys( cpi ), i, orderindices = {}
 		for( i = 0 ; i < tx.length ; i ++ ){
 			orderindices[tx[i]] = this.getOrderIndexOfCell( tx[i], cpi[tx[i]] )
@@ -358,7 +358,20 @@ CPMStats.prototype = {
 			cp[t].push( px[i] )
 		}
 		return cp
- 	}
+ 	},
+
+	cellborderpixelsi : function(){
+		let cp = {},t
+		const px = this.C.cellborderpixels.elements
+		for( let i = 0; i < px.length; i++ ){
+			t = this.C.cellpixelstype[px[i]]
+			if( !(t in cp ) ){
+				cp[t] = []
+			}
+			cp[t].push( px[i] )
+		}
+		return cp		
+	}
  	
 }
 

--- a/src/CPMStats.js
+++ b/src/CPMStats.js
@@ -5,15 +5,6 @@
 function CPMStats( C ){
 	this.C = C
 	this.ndim = this.C.ndim
-	if( this.ndim == 2 ){
-		this.getCentroids = this.getCentroids2D
-		this.centroids = this.centroids2D
-		this.getCentroidOf = this.getCentroidOf2D
-	} else {
-		this.getCentroids = this.getCentroids3D
-		this.centroids = this.centroids3D
-		this.getCentroidOf = this.getCentroidOf3D
-	}
 }
 
 CPMStats.prototype = {
@@ -33,108 +24,142 @@ CPMStats.prototype = {
 		}
 		return r
 	},
-	// center of mass of cell t 
-	getCentroidOf2D : function( t ){
-		var j, cx, cy
-
-		// array of pixels belonging to cell t
-		var cpt = this.cellpixels()[t]
+	// For computing mean and variance with online algorithm
+	updateOnline : function( aggregate, value ){
 		
-		// loop over pixels and sum up coordinates
-		for( j = 0; j < cpt.length ; j++ ){
-			cx += cpt[j][0]
-			cy += cpt[j][1]
-		}
+		var delta, delta2
 
-		// divide to get mean coordinates
-		cx /= j; cy /= j
+		aggregate.count ++
+		delta = value - aggregate.mean
+		aggregate.mean += delta/aggregate.count
+		delta2 = value - aggregate.mean
+		aggregate.sqd += delta*delta2
 
-		return [cx, cy]
+		return aggregate
 	},
-	getCentroidOf3D : function( t ){
-		var j, cx, cy, cz
+	newOnline : function(){
+		return( { count : 0, mean : 0, sqd : 0 } ) 
+	},
+	// return mean and variance of coordinates in a given dimension for cell t
+	// (dimension as 0,1, or 2)
+	cellStats : function( t, dim ){
 
-		// array of pixels belonging to cell t
-		var cpt = this.cellpixels()[t]
-		
-		// loop over pixels and sum up coordinates
-		for( j = 0; j < cpt.length ; j++ ){
-			cx += cpt[j][0]
-			cy += cpt[j][1]
-			cz += cpt[j][2]
+		var aggregate, cpt, j, stats
+
+		// the cellpixels object can be given as the third argument
+		if( arguments.length == 3){
+			cpt = arguments[2][t]
+		} else {
+			cpt = this.cellpixels()[t]
 		}
-		// divide to get mean coordinates
-		cx /= j; cy /= j; cz /= j
-		return [cx, cy, cz]
+
+		// compute using online algorithm
+		aggregate = this.newOnline()
+
+		// loop over pixels to update the aggregate
+		for( j = 0; j < cpt.length; j++ ){
+			aggregate = this.updateOnline( aggregate, cpt[j][dim] )
+		}
+
+		// get mean and variance
+		stats = { mean : aggregate.mean, variance : aggregate.sqd / ( aggregate.count - 1 ) }
+		return stats
+	},
+	// get the length (variance) of cell in a given dimension
+	getLengthOf : function( t, dim ){
+		
+		// get mean and sd in x direction
+		var stats = this.cellStats( t, dim )
+		return stats.variance
+
+	},
+	// get the range of coordinates in dim for cell t
+	getRangeOf : function( t, dim ){
+
+		var minc, maxc, cpt, j
+
+		// the cellpixels object can be given as the third argument
+		if( arguments.length == 3){
+			cpt = arguments[2][t]
+		} else {
+			cpt = this.cellpixels()[t]
+		}
+
+		// loop over pixels to find min and max
+		minc = cpt[0][dim]
+		maxc = cpt[0][dim]
+		for( j = 1; j < cpt.length; j++ ){
+			if( cpt[j][dim] < minc ) minc = cpt[j][dim]
+			if( cpt[j][dim] > maxc ) maxc = cpt[j][dim]
+		}
+		
+		return( maxc - minc )		
+
+	},
+	// center of mass of cell t
+	// the cellpixels object can be given as the second argument
+	getCentroidOf : function( t ){
+		var j, dim, cvec, cpt
+		if( arguments.length == 2 ){
+			cpt = arguments[1][t]
+		} else {
+			cpt = this.cellpixels()[t]
+		}
+		// fill the array cvec with zeros first
+		cvec = Array.apply(null, Array(this.ndim)).map(Number.prototype.valueOf,0)
+
+		// loop over pixels to sum up coordinates
+		for( j = 0; j < cpt.length; j++ ){
+			// loop over coordinates x,y,z
+			for( dim = 0; dim < this.ndim; dim++ ){
+				cvec[dim] += cpt[j][dim]
+			}		
+		}
+
+		// divide to get mean
+		for( dim = 0; dim < this.ndim; dim++ ){
+			cvec[dim] /= j
+		}
+
+		return cvec
 	},
 	// center of mass (return)
-	getCentroids2D : function(){
+	getCentroids : function(){
 		var cp = this.cellpixels()
-		var tx = Object.keys( cp ), cx, cy, i, j, r = []
-		for( i = 0 ; i < tx.length ; i ++ ){
-			cx=0; cy=0
-			// loop over the cells in cp
-			for( j = 0 ; j < cp[tx[i]].length ; j ++ ){
-				cx += cp[tx[i]][j][0]
-				cy += cp[tx[i]][j][1]
+		var tx = Object.keys( cp )
+		var cvec, r = [], current, i
+
+		// loop over the cells in tx to get their centroids
+		for( i = 0; i < tx.length; i++ ){
+			cvec = this.getCentroidOf( tx[i] )
+
+			// output depending on ndim
+			current = { id : tx[i], x : cvec[0], y : cvec[1] }
+			if( this.ndim == 3 ){
+				current["z"] = cvec[2]			
 			}
-			cx /= j; cy /= j
-			r.push( { id : tx[i], x : cx, y : cy } )
+			r.push( current )
 		}
-		return r		
-	},
-	getCentroids3D : function(){
-		var cp = this.cellpixels()
-		var tx = Object.keys( cp ), cx, cy, cz, i, j, r = []
-		for( i = 0 ; i < tx.length ; i ++ ){
-			cx=0; cy=0; cz=0
-			for( j = 0 ; j < cp[tx[i]].length ; j ++ ){
-				cx += cp[tx[i]][j][0]
-				cy += cp[tx[i]][j][1]
-				cz += cp[tx[i]][j][2]
-			}
-			cx /= j; cy /= j ; cz /= j
-			r.push( { id : tx[i], x : cx, y : cy, z : cz } )
-		}
-		return r		
+		return r
 	},
 	// center of mass (print to console)
-	centroids3D : function(){
+	centroids : function(){
 		var cp = this.cellpixels()
-		var tx = Object.keys( cp ), cx, cy, cz, i, j
-		for( i = 0 ; i < tx.length ; i ++ ){
-			cx=0; cy=0; cz=0
-			for( j = 0 ; j < cp[tx[i]].length ; j ++ ){
-				cx += cp[tx[i]][j][0]
-				cy += cp[tx[i]][j][1]
-				cz += cp[tx[i]][j][2]
-			}
-			cx /= j; cy /= j ; cz /= j
+		var tx = Object.keys( cp )	
+		var cvec, i
+
+		// loop over the cells in tx to get their centroids
+		for( i = 0; i < tx.length; i++ ){
+			cvec = this.getCentroidOf( tx[i] )
+
 			// eslint-disable-next-line no-console
-			console.log( tx[i] +"\t"+ 
-				this.C.time +"\t"+
-				this.C.time +"\t"+
-				cx  +"\t"+
-				cy  +"\t"+
-				cz )
-		}
-	},
-	centroids2D : function(){
-		var cp = this.cellpixels()
-		var tx = Object.keys( cp ), cx, cy, i, j
-		for( i = 0 ; i < tx.length ; i ++ ){
-			cx=0; cy=0
-			for( j = 0 ; j < cp[tx[i]].length ; j ++ ){
-				cx += cp[tx[i]][j][0]
-				cy += cp[tx[i]][j][1]
-			}
-			cx /= j; cy /= j 
-			// eslint-disable-next-line no-console
-			console.log( tx[i] +"\t"+ 
-				this.C.time +"\t"+
-				this.C.time +"\t"+
-				cx  +"\t"+
-				cy  )
+			console.log( 
+				tx[i] + "\t" +
+				this.C.time + "\t" +
+				this.C.time + "\t" +
+				cvec.join("\t")
+			)
+
 		}
 	},
 	// returns an object with a key for each celltype (identity). 

--- a/src/CPMStats.js
+++ b/src/CPMStats.js
@@ -312,7 +312,7 @@ CPMStats.prototype = {
 			// we only consider non-zero gradients for the order index
 			if( gn != 0 ){
 				for( d = 0; d < this.C.ndim; d++ ){
-					gradientsum[d] += g[d]/gn
+					gradientsum[d] += 100*g[d]/gn/cellindices.length
 				}
 			}
 		}
@@ -323,7 +323,7 @@ CPMStats.prototype = {
 		return orderindex	
 	},
 	getOrderIndices : function( ){
-		var cpi = this.cellpixelsi()
+		var cpi = this.cellborderpixelsi()
 		var tx = Object.keys( cpi ), i, orderindices = {}
 		for( i = 0 ; i < tx.length ; i ++ ){
 			orderindices[tx[i]] = this.getOrderIndexOfCell( tx[i], cpi[tx[i]] )
@@ -351,6 +351,19 @@ CPMStats.prototype = {
 		var cp = {}
 		var px = Object.keys( this.C.cellpixelstype ), t, i
 		for( i = 0 ; i < px.length ; i ++ ){
+			t = this.C.cellpixelstype[px[i]]
+			if( !(t in cp ) ){
+				cp[t] = []
+			}
+			cp[t].push( px[i] )
+		}
+		return cp
+	},
+	
+	cellborderpixelsi : function(){
+		let cp = {}, t
+		const px = this.C.cellborderpixels.elements
+		for( let i = 0; i < px.length; i++ ){
 			t = this.C.cellpixelstype[px[i]]
 			if( !(t in cp ) ){
 				cp[t] = []

--- a/src/CPMStats.js
+++ b/src/CPMStats.js
@@ -96,7 +96,7 @@ CPMStats.prototype = {
 		return( maxc - minc )		
 
 	},
-	//
+	// Compute connected components of the cell ( to check connectivity )
 	getConnectedComponentOfCell : function( t, cellindices ){
 		if( cellindices.length == 0 ){ return }
 
@@ -110,7 +110,8 @@ CPMStats.prototype = {
 				var e = parseInt(q.pop())
 				volume[k] ++
 				var ne = myself.C.neighi( e )
-				for( var i = 0 ; i < ne.length ; i ++ ){									if( myself.C.pixti( ne[i] ) == t &&
+				for( var i = 0 ; i < ne.length ; i ++ ){
+					if( myself.C.pixti( ne[i] ) == t &&
 						!visited.hasOwnProperty(ne[i]) ){
 						q.push(ne[i])
 						visited[ne[i]]=1
@@ -150,6 +151,28 @@ CPMStats.prototype = {
 			}
 		}
 		return r
+	},
+	// Compute percentage of pixels with activity > threshold
+	getPercentageActOfCell : function( t, cellindices, threshold ){
+		if( cellindices.length == 0 ){ return }
+		var i, count = 0
+
+		for( i = 0 ; i < cellindices.length ; i ++ ){
+			if( this.C.pxact( cellindices[i] ) > threshold ){
+				count++
+			}
+		}
+		return 100*(count/cellindices.length)
+	
+	},
+	getPercentageAct : function( threshold ){
+		var cpi = this.cellpixelsi()
+		var tx = Object.keys( cpi ), i, activities = {}
+		for( i = 0 ; i < tx.length ; i ++ ){
+			activities[tx[i]] = this.getPercentageActOfCell( tx[i], cpi[tx[i]], threshold )
+		}
+		return activities
+	
 	},
 	// center of mass of cell t
 	// the cellpixels object can be given as the second argument

--- a/src/CPMStats.js
+++ b/src/CPMStats.js
@@ -358,8 +358,8 @@ CPMStats.prototype = {
 			cp[t].push( px[i] )
 		}
 		return cp
- 	}
- 	
+	}
+	
 }
 
 

--- a/src/CPMStats.js
+++ b/src/CPMStats.js
@@ -96,6 +96,61 @@ CPMStats.prototype = {
 		return( maxc - minc )		
 
 	},
+	//
+	getConnectedComponentOfCell : function( t, cellindices ){
+		if( cellindices.length == 0 ){ return }
+
+		var visited = {}, k=1, volume = {}, myself = this
+
+		var labelComponent = function(seed, k){
+			var q = [parseInt(seed)]
+			visited[q[0]] = 1
+			volume[k] = 0
+			while( q.length > 0 ){
+				var e = parseInt(q.pop())
+				volume[k] ++
+				var ne = myself.C.neighi( e )
+				for( var i = 0 ; i < ne.length ; i ++ ){									if( myself.C.pixti( ne[i] ) == t &&
+						!visited.hasOwnProperty(ne[i]) ){
+						q.push(ne[i])
+						visited[ne[i]]=1
+					}
+				}
+			}
+		}
+
+		for( var i = 0 ; i < cellindices.length ; i ++ ){
+			if( !visited.hasOwnProperty( cellindices[i] ) ){
+				labelComponent( cellindices[i], k )
+				k++
+			}
+		}
+
+		return volume
+	},
+	getConnectedComponents : function(){
+		var cpi = this.cellpixelsi()
+		var tx = Object.keys( cpi ), i, volumes = {}
+		for( i = 0 ; i < tx.length ; i ++ ){
+			volumes[tx[i]] = this.getConnectedComponentOfCell( tx[i], cpi[tx[i]] )
+		}
+		return volumes
+	},
+	// Compute probabilities that two pixels taken at random come from the same cell.
+	getConnectedness : function(){
+		var v = this.getConnectedComponents(), s = {}, r = {}, i, j
+		for( i in v ){
+			s[i] = 0
+			r[i] = 0
+			for( j in v[i] ){
+				s[i] += v[i][j]
+			}
+			for( j in v[i] ){
+				r[i] += (v[i][j]/s[i]) * (v[i][j]/s[i])
+			}
+		}
+		return r
+	},
 	// center of mass of cell t
 	// the cellpixels object can be given as the second argument
 	getCentroidOf : function( t ){
@@ -175,7 +230,21 @@ CPMStats.prototype = {
 			cp[t].push( this.C.i2p( px[i] ) )
 		}
 		return cp
-	}
+	},
+
+	cellpixelsi : function(){
+		var cp = {}
+		var px = Object.keys( this.C.cellpixelstype ), t, i
+		for( i = 0 ; i < px.length ; i ++ ){
+			t = this.C.cellpixelstype[px[i]]
+			if( !(t in cp ) ){
+				cp[t] = []
+			}
+			cp[t].push( px[i] )
+		}
+		return cp
+ 	}
+ 	
 }
 
 

--- a/src/CPMchemotaxis.js
+++ b/src/CPMchemotaxis.js
@@ -1,6 +1,7 @@
 /** This extends the CPM from CPM.js with a chemotaxis module. 
-Can be used for two- or three-dimensional simulations. 
-	Usable from browser and node.js.
+Can be used for two- or three-dimensional simulations, but visualization
+is currently supported only in 2D. 
+Currently usable from browser only.
 */
 
 
@@ -210,59 +211,6 @@ CPM.prototype.monteCarloStep = function(){
 
 		this.time++ // update time with one MCS.
 }
-
-
-/* ------------------ CANVAS --------------------------------------- */
-
-CPMCanvas.prototype.setopacity = function( alpha ){
-	this.ctx.globalAlpha = alpha
-}
-
-CPMCanvas.prototype.chemokineIntensity = function( p ){
-
-	var gradienttype = this.C.conf["GRADIENT_TYPE"]
-	var gradientvec = this.C.conf["GRADIENT_DIRECTION"]
-
-	if( gradienttype == "linear" ){
-		var gmax = gradientvec[0]*this.C.field_size.x + gradientvec[1]*this.C.field_size.y
-		var gval = 0.0 + (gradientvec[0]*p[0]) + ( gradientvec[1]*p[1] )
-		return( gval/gmax )
-	} else if( gradienttype == "radial" ){
-		var maxx = gradientvec[0], maxy = gradientvec[1]
-		if( this.C.field_size.x - maxx > maxx ){
-			maxx = this.C.field_size.x - maxx
-		}
-		if( this.C.field_size.y - maxy > maxy ){
-			maxy = this.C.field_size.y - maxy
-		}
-		var distx = p[0] - gradientvec[0], disty = p[1] - gradientvec[1]
-		var gmax = Math.sqrt( maxx*maxx + maxy*maxy )
-		var gval = 0.0 + Math.sqrt( distx*distx + disty*disty )
-
-	} else {
-		throw("Unknown gradienttype")
-	}
-	return (1-gval/gmax)
-}
-CPMCanvas.prototype.drawChemokineGradient = function( col ){
-
-	var i,j,alpha
-	col = col || "000000"
-	this.col( col )
-
-	for( i = 0; i < this.C.field_size.x; i++ ){
-		for( j = 0; j < this.C.field_size.y; j++ ){
-			alpha = 1*this.chemokineIntensity( [i,j] )
-			this.setopacity( alpha*alpha )
-
-			
-			this.pxf( [i,j] )
-		}
-	}
-	this.setopacity( 1 )
-
-}
-
 
 
 /* This allows using the code in either the browser or with nodejs. */

--- a/src/CPMchemotaxis.js
+++ b/src/CPMchemotaxis.js
@@ -1,222 +1,92 @@
-/** This extends the CPM from CPM.js with a chemotaxis module. 
+/* This extends the CPM from CPM.js with a chemotaxis module. 
 Can be used for two- or three-dimensional simulations, but visualization
-is currently supported only in 2D. 
-Currently usable from browser only.
+is currently supported only in 2D. Usable from browser and node.
 */
 
 
 /* ------------------ CHEMOTAXIS --------------------------------------- */
-
-
-/*  To bias a copy attempt p1->p2 in the direction of target point pt.
-	Vector p1 -> p2 is the direction of the copy attempt, 
-	Vector p1 -> pt is the preferred direction. Then this function returns the cosine
-	of the angle alpha between these two vectors. This cosine is 1 if the angle between
-	copy attempt direction and preferred direction is 0 (when directions are the same), 
-	-1 if the angle is 180 (when directions are opposite), and 0 when directions are
-	perpendicular. */
-CPM.prototype.pointAttractor = function( p1, p2, pt ){
-	var r = 0., i, norm1 = 0, norm2 = 0, d1=0., d2=0.
-	for( i=0 ; i < p1.length ; i ++ ){
-		d1 = pt[i]-p1[i]; d2 = p2[i]-p1[i]
-		r += d1 * d2
-		norm1 += d1*d1
-		norm2 += d2*d2
-	}
-	return r/Math.sqrt(norm1)/Math.sqrt(norm2)
-
+if( typeof CPM == "undefined" ){
+	CPM = require("./CPM.js" )	
 }
 
-/* To bias a copy attempt p1 -> p2 in the direction of vector 'dir'.
-This implements a linear gradient rather than a radial one as with pointAttractor. */
-CPM.prototype.linAttractor = function( p1, p2, dir ){
+class CPMchemotaxis extends CPM {
 
-	var r = 0., i, norm1 = 0, norm2 = 0, d1 = 0., d2 = 0.
-	// loops over the coordinates x,y,(z)
-	for( i = 0; i < p1.length ; i++ ){
-		// direction of the copy attempt on this coordinate is from p1 to p2
-		d1 = p2[i] - p1[i]
-
-		// direction of the gradient
-		d2 = dir[i]
-		r += d1 * d2 
-		norm1 += d1*d1
-		norm2 += d2*d2
-	}
-	return r/Math.sqrt(norm1)/Math.sqrt(norm2)
-}
-
-
-CPM.prototype.deltaHchemotaxis = function( sourcei, targeti, src_type, tgt_type ){
-
-	var gradienttype = this.conf["GRADIENT_TYPE"]
-	var gradientvec = this.conf["GRADIENT_DIRECTION"]
-	var bias 
-
-	if( gradienttype == "radial" ){
-		bias = this.pointAttractor( this.i2p(sourcei), this.i2p(targeti),gradientvec )
-	} else if( gradienttype == "linear" ){
-		bias = this.linAttractor( this.i2p(sourcei), this.i2p(targeti),gradientvec )
-	} else {
-		throw("Unknown GRADIENT_TYPE. Please choose either 'linear' or 'radial'." )
-	}
-
-	// if source is non background, lambda chemotaxis is of the source cell.
-	// if source is background, use lambda chemotaxis of target cell.
-	if( src_type != 0 ){
-		lambdachem = this.par("LAMBDA_CHEMOTAXIS",src_type )
-	} else {
-		lambdachem = this.par("LAMBDA_CHEMOTAXIS",tgt_type )
-	}	
-
-	return -bias*lambdachem
-}
-
-
-/* ------------------ HAMILTONIAN COMPUTATION ------------------------------ */
-
-CPM.prototype.deltaHadhesion = function( sourcei, targeti, src_type, tgt_type ){
-	return this.H( targeti, src_type ) - this.H( targeti, tgt_type )
-}
-
-CPM.prototype.deltaHvolume = function( sourcei, targeti, src_type, tgt_type ){
-
-	// volume gain of src cell
-	var deltaH = this.volconstraint( 1, src_type ) - 
-		this.volconstraint( 0, src_type )
-	// volume loss of tgt cell
-	deltaH += this.volconstraint( -1, tgt_type ) - 
-		this.volconstraint( 0, tgt_type )
-
-	return deltaH
-
-}
-
-// invasiveness. If there is a celltype a that prefers to invade
-// pixels of type b. Currently not used.
-CPM.prototype.deltaHinvasiveness = function( sourcei, targeti, src_type, tgt_type ){
-	var deltaH = 0	
-	if( tgt_type != 0 && src_type != 0 && this.conf.INV ){
-		deltaH += this.par( "INV", tgt_type, src_type )
-	}
-	return -deltaH
-}
-
-CPM.prototype.deltaHperimeter = function( sourcei, targeti, src_type, tgt_type ){
-	return this.perconstrainti( targeti, tgt_type, src_type )
-}
-CPM.prototype.deltaHactmodel = function( sourcei, targeti, src_type, tgt_type ){
-
-	var deltaH = 0
-
-	// use parameters for the source cell, unless that is the background.
-	// In that case, use parameters of the target cell.
-	if( src_type != 0 ){
-		maxact = this.par("MAX_ACT",src_type)
-		lambdaact = this.par("LAMBDA_ACT",src_type)
-	} else {
-		// special case: punishment for a copy attempt from background into
-		// an active cell. This effectively means that the active cell retracts,
-		// which is different from one cell pushing into another (active) cell.
-		maxact = this.par("MAX_ACT",tgt_type)
-		lambdaact = this.par("LAMBDA_ACT",tgt_type)
-	}
-	if( maxact > 0 ){
-		deltaH += lambdaact*(this.activityAt( targeti ) - this.activityAt( sourcei ))/maxact
-	}
-	return deltaH
-}
-
-// returns both change in hamiltonian and perimeter
-CPM.prototype.deltaH = function( sourcei, targeti, src_type, tgt_type ){
-
-	var terms = ["adhesion","volume","perimeter","actmodel","chemotaxis"], currentterm
-	var dHlog = {}, per
-	
-	var r = 0.0
-	for( var i = 0 ; i < terms.length ; i++ ){
-		currentterm = this["deltaH"+terms[i]].call( this,sourcei,targeti,src_type,tgt_type )
-		if( terms[i]=="perimeter"){
-			r+=currentterm.r
-			per = currentterm
-			dHlog[terms[i]] = currentterm.r
-		} else {
-			r += currentterm
-			dHlog[terms[i]] = currentterm
-		}
+	constructor( ndim, field_size, conf ) {
+		// call the parent (CPM) constructor
+		super( ndim, field_size, conf )
 		
-	}
-	/*
-	var adhesion = this.deltaHadhesion( targeti, src_type, tgt_type )
-	var volume = this.deltaHvolume( src_type, tgt_type )
-	var per = this.perconstrainti( targeti, tgt_type, src_type )
-	var hper = per.r
-	var invn = this.deltaHinvasiveness( src_type, tgt_type )
-	var act = this.deltaHactmodel( sourcei, targeti, src_type, tgt_type )
-	var conn = this.connectivityConstraint( targeti, tgt_type, src_type )
-	var chemotaxis = this.deltaHchemotaxis( sourcei, targeti, src_type, tgt_type )
-	*/
-	if( ( this.logterms || 0 ) && this.time % 100 == 0 ){
-		//console.log( {adh: adhesion, vol: volume, p: per.r, inv: invn, act: act, conn:conn, chem: chemotaxis } )
-		console.log( dHlog )
+		this.terms.push( "chemotaxis" )
 	}
 
-	//var dh = adhesion + volume + per.r + hper + invn + act + conn -chemotaxis
 
-	return ({ dH: r, per: per })
+	/*  To bias a copy attempt p1->p2 in the direction of target point pt.
+		Vector p1 -> p2 is the direction of the copy attempt, 
+		Vector p1 -> pt is the preferred direction. Then this function returns the cosine
+		of the angle alpha between these two vectors. This cosine is 1 if the angle between
+		copy attempt direction and preferred direction is 0 (when directions are the same), 
+		-1 if the angle is 180 (when directions are opposite), and 0 when directions are
+		perpendicular. */
+	pointAttractor ( p1, p2, pt ){
+		let r = 0., norm1 = 0, norm2 = 0, d1=0., d2=0.
+		for( let i=0 ; i < p1.length ; i ++ ){
+			d1 = pt[i]-p1[i]; d2 = p2[i]-p1[i]
+			r += d1 * d2
+			norm1 += d1*d1
+			norm2 += d2*d2
+		}
+		return r/Math.sqrt(norm1)/Math.sqrt(norm2)
+	}
+	
+	/* To bias a copy attempt p1 -> p2 in the direction of vector 'dir'.
+	This implements a linear gradient rather than a radial one as with pointAttractor. */
+	linAttractor ( p1, p2, dir ){
 
-}
+		let r = 0., norm1 = 0, norm2 = 0, d1 = 0., d2 = 0.
+		// loops over the coordinates x,y,(z)
+		for( let i = 0; i < p1.length ; i++ ){
+			// direction of the copy attempt on this coordinate is from p1 to p2
+			d1 = p2[i] - p1[i]
 
+			// direction of the gradient
+			d2 = dir[i]
+			r += d1 * d2 
+			norm1 += d1*d1
+			norm2 += d2*d2
+		}
+		return r/Math.sqrt(norm1)/Math.sqrt(norm2)
+	}
+	
+	deltaHchemotaxis ( sourcei, targeti, src_type, tgt_type ){
 
-CPM.prototype.monteCarloStep = function(){
+		const gradienttype = this.conf["GRADIENT_TYPE"]
+		const gradientvec = this.conf["GRADIENT_DIRECTION"]
+		let bias, lambdachem
 
-		var delta_t = 0.0, p1i, p2i, src_type, tgt_type, N, hamiltonian
-
-		// this loop tracks the number of copy attempts until one MCS is completed.
-		while( delta_t < 1.0 ){
-
-			// This is the expected time (in MCS) you would expect it to take to
-			// randomly draw another border pixel.
-			delta_t += 1./(this.bgborderpixels.length + this.cellborderpixels.length)
-
-			// Randomly sample one of the CPM border pixels (the "source" (src)),
-			// and one of its neighbors (the "target" (tgt)).
-			if( this.ran( 0, this.bgborderpixels.length + this.cellborderpixels.length )
-				< this.bgborderpixels.length ){
-				p1i = this.bgborderpixels.sample()
-			} else {
-				p1i = this.cellborderpixels.sample()
-			}
-			
-			N = this.neighi( p1i )
-			p2i = N[this.ran(0,N.length-1)]
-			
-			src_type = this.pixti( p1i )
-			tgt_type = this.pixti( p2i )
-
-			// only compute the Hamiltonian if source and target belong to a different cell,
-			// and do not allow a copy attempt into the stroma. Only continue if the copy attempt
-			// would result in a viable cell.
-			if( tgt_type >= 0 && src_type != tgt_type ){
-
-				hamiltonian = this.deltaH( p1i, p2i, src_type, tgt_type )
-
-				// probabilistic success of copy attempt
-				if( this.docopy( hamiltonian.dH ) ){
-					this.setpixi( p2i, src_type, hamiltonian.per.Pup )
-				}
-			}
-
+		if( gradienttype == "radial" ){
+			bias = this.pointAttractor( this.i2p(sourcei), this.i2p(targeti),gradientvec )
+		} else if( gradienttype == "linear" ){
+			bias = this.linAttractor( this.i2p(sourcei), this.i2p(targeti),gradientvec )
+		} else {
+			throw("Unknown GRADIENT_TYPE. Please choose either 'linear' or 'radial'." )
 		}
 
-		this.time++ // update time with one MCS.
+		// if source is non background, lambda chemotaxis is of the source cell.
+		// if source is background, use lambda chemotaxis of target cell.
+		if( src_type != 0 ){
+			lambdachem = this.par("LAMBDA_CHEMOTAXIS",src_type )
+		} else {
+			lambdachem = this.par("LAMBDA_CHEMOTAXIS",tgt_type )
+		}	
+
+		return -bias*lambdachem
+	}
+
 }
+
 
 
 /* This allows using the code in either the browser or with nodejs. */
 if( typeof module !== "undefined" ){
-	var CPM = require("./CPM.js" )	
-	var DiceSet = require("./DiceSet.js")
-	module.exports = CPM
+	module.exports = CPMchemotaxis
 }
 

--- a/src/CPMchemotaxis.js
+++ b/src/CPMchemotaxis.js
@@ -1,0 +1,252 @@
+/** This extends the CPM from CPM.js with a chemotaxis module. 
+Can be used for two- or three-dimensional simulations. 
+	Usable from browser and node.js.
+*/
+
+
+/* ------------------ CHEMOTAXIS --------------------------------------- */
+
+
+/*  To bias a copy attempt p1->p2 in the direction of target point pt.
+	Vector p1 -> p2 is the direction of the copy attempt, 
+	Vector p1 -> pt is the preferred direction. Then this function returns the cosine
+	of the angle alpha between these two vectors. This cosine is 1 if the angle between
+	copy attempt direction and preferred direction is 0 (when directions are the same), 
+	-1 if the angle is 180 (when directions are opposite), and 0 when directions are
+	perpendicular. */
+CPM.prototype.pointAttractor = function( p1, p2, pt ){
+	var r = 0., i, norm1 = 0, norm2 = 0, d1=0., d2=0.
+	for( i=0 ; i < p1.length ; i ++ ){
+		d1 = pt[i]-p1[i]; d2 = p2[i]-p1[i]
+		r += d1 * d2
+		norm1 += d1*d1
+		norm2 += d2*d2
+	}
+	return r/Math.sqrt(norm1)/Math.sqrt(norm2)
+
+}
+
+/* To bias a copy attempt p1 -> p2 in the direction of vector 'dir'.
+This implements a linear gradient rather than a radial one as with pointAttractor. */
+CPM.prototype.linAttractor = function( p1, p2, dir ){
+
+	var r = 0., i, norm1 = 0, norm2 = 0, d1 = 0., d2 = 0.
+	// loops over the coordinates x,y,(z)
+	for( i = 0; i < p1.length ; i++ ){
+		// direction of the copy attempt on this coordinate is from p1 to p2
+		d1 = p2[i] - p1[i]
+
+		// direction of the gradient
+		d2 = dir[i]
+		r += d1 * d2 
+		norm1 += d1*d1
+		norm2 += d2*d2
+	}
+	return r/Math.sqrt(norm1)/Math.sqrt(norm2)
+}
+
+
+CPM.prototype.deltaHchemotaxis = function( sourcei, targeti, src_type, tgt_type ){
+
+	var gradienttype = this.conf["GRADIENT_TYPE"]
+	var gradientvec = this.conf["GRADIENT_DIRECTION"]
+	var bias 
+
+	if( gradienttype == "radial" ){
+		bias = this.pointAttractor( this.i2p(sourcei), this.i2p(targeti),gradientvec )
+	} else if( gradienttype == "linear" ){
+		bias = this.linAttractor( this.i2p(sourcei), this.i2p(targeti),gradientvec )
+	} else {
+		throw("Unknown GRADIENT_TYPE. Please choose either 'linear' or 'radial'." )
+	}
+
+	// if source is non background, lambda chemotaxis is of the source cell.
+	// if source is background, use lambda chemotaxis of target cell.
+	if( src_type != 0 ){
+		lambdachem = this.par("LAMBDA_CHEMOTAXIS",src_type )
+	} else {
+		lambdachem = this.par("LAMBDA_CHEMOTAXIS",tgt_type )
+	}	
+
+	return bias*lambdachem
+}
+
+
+/* ------------------ HAMILTONIAN COMPUTATION ------------------------------ */
+
+CPM.prototype.deltaHadhesion = function( targeti, src_type, tgt_type ){
+	return this.H( targeti, src_type ) - this.H( targeti, tgt_type )
+}
+
+CPM.prototype.deltaHvolume = function( src_type, tgt_type ){
+
+	// volume gain of src cell
+	var deltaH = this.volconstraint( 1, src_type ) - 
+		this.volconstraint( 0, src_type )
+	// volume loss of tgt cell
+	deltaH += this.volconstraint( -1, tgt_type ) - 
+		this.volconstraint( 0, tgt_type )
+
+	return deltaH
+
+}
+
+// invasiveness. If there is a celltype a that prefers to invade
+// pixels of type b. Currently not used.
+CPM.prototype.deltaHinvasiveness = function( src_type, tgt_type ){
+	var deltaH = 0	
+	if( tgt_type != 0 && src_type != 0 && this.conf.INV ){
+		deltaH += this.par( "INV", tgt_type, src_type )
+	}
+	return -deltaH
+}
+
+CPM.prototype.deltaHactmodel = function( sourcei, targeti, src_type, tgt_type ){
+
+	var deltaH = 0
+
+	// use parameters for the source cell, unless that is the background.
+	// In that case, use parameters of the target cell.
+	if( src_type != 0 ){
+		maxact = this.par("MAX_ACT",src_type)
+		lambdaact = this.par("LAMBDA_ACT",src_type)
+	} else {
+		// special case: punishment for a copy attempt from background into
+		// an active cell. This effectively means that the active cell retracts,
+		// which is different from one cell pushing into another (active) cell.
+		maxact = this.par("MAX_ACT",tgt_type)
+		lambdaact = this.par("LAMBDA_ACT",tgt_type)
+	}
+	if( maxact > 0 ){
+		deltaH += lambdaact*(this.activityAt( targeti ) - this.activityAt( sourcei ))/maxact
+	}
+	return deltaH
+}
+
+// returns both change in hamiltonian and perimeter
+CPM.prototype.deltaH = function( sourcei, targeti, src_type, tgt_type ){
+
+	var adhesion = this.deltaHadhesion( targeti, src_type, tgt_type )
+	var volume = this.deltaHvolume( src_type, tgt_type )
+	var per = this.perconstrainti( targeti, tgt_type, src_type )
+	var hper = per.r
+	var invn = this.deltaHinvasiveness( src_type, tgt_type )
+	var act = this.deltaHactmodel( sourcei, targeti, src_type, tgt_type )
+	var conn = this.connectivityConstraint( targeti, tgt_type, src_type )
+	var chemotaxis = this.deltaHchemotaxis( sourcei, targeti, src_type, tgt_type )
+
+	if( ( this.logterms || 0 ) && this.time % 100 == 0 ){
+		console.log( {adh: adhesion, vol: volume, p: per.r, inv: invn, act: act, conn:conn, chem: chemotaxis } )
+	}
+
+	var dh = adhesion + volume + per.r + hper + invn + act + conn -chemotaxis
+
+	return ({ dH: dh, per: per })
+
+}
+
+
+CPM.prototype.monteCarloStep = function(){
+
+		var delta_t = 0.0, p1i, p2i, src_type, tgt_type, N, hamiltonian
+
+		// this loop tracks the number of copy attempts until one MCS is completed.
+		while( delta_t < 1.0 ){
+
+			// This is the expected time (in MCS) you would expect it to take to
+			// randomly draw another border pixel.
+			delta_t += 1./(this.bgborderpixels.length + this.cellborderpixels.length)
+
+			// Randomly sample one of the CPM border pixels (the "source" (src)),
+			// and one of its neighbors (the "target" (tgt)).
+			if( this.ran( 0, this.bgborderpixels.length + this.cellborderpixels.length )
+				< this.bgborderpixels.length ){
+				p1i = this.bgborderpixels.sample()
+			} else {
+				p1i = this.cellborderpixels.sample()
+			}
+			
+			N = this.neighi( p1i )
+			p2i = N[this.ran(0,N.length-1)]
+			
+			src_type = this.pixti( p1i )
+			tgt_type = this.pixti( p2i )
+
+			// only compute the Hamiltonian if source and target belong to a different cell,
+			// and do not allow a copy attempt into the stroma. Only continue if the copy attempt
+			// would result in a viable cell.
+			if( tgt_type >= 0 && src_type != tgt_type ){
+
+				hamiltonian = this.deltaH( p1i, p2i, src_type, tgt_type )
+
+				// probabilistic success of copy attempt
+				if( this.docopy( hamiltonian.dH ) ){
+					this.setpixi( p2i, src_type, hamiltonian.per.Pup )
+				}
+			}
+
+		}
+
+		this.time++ // update time with one MCS.
+}
+
+
+/* ------------------ CANVAS --------------------------------------- */
+
+CPMCanvas.prototype.setopacity = function( alpha ){
+	this.ctx.globalAlpha = alpha
+}
+
+CPMCanvas.prototype.chemokineIntensity = function( p ){
+
+	var gradienttype = this.C.conf["GRADIENT_TYPE"]
+	var gradientvec = this.C.conf["GRADIENT_DIRECTION"]
+
+	if( gradienttype == "linear" ){
+		var gmax = gradientvec[0]*this.C.field_size.x + gradientvec[1]*this.C.field_size.y
+		var gval = 0.0 + (gradientvec[0]*p[0]) + ( gradientvec[1]*p[1] )
+		return( gval/gmax )
+	} else if( gradienttype == "radial" ){
+		var maxx = gradientvec[0], maxy = gradientvec[1]
+		if( this.C.field_size.x - maxx > maxx ){
+			maxx = this.C.field_size.x - maxx
+		}
+		if( this.C.field_size.y - maxy > maxy ){
+			maxy = this.C.field_size.y - maxy
+		}
+		var distx = p[0] - gradientvec[0], disty = p[1] - gradientvec[1]
+		var gmax = Math.sqrt( maxx*maxx + maxy*maxy )
+		var gval = 0.0 + Math.sqrt( distx*distx + disty*disty )
+
+	} else {
+		throw("Unknown gradienttype")
+	}
+	return (1-gval/gmax)
+}
+CPMCanvas.prototype.drawChemokineGradient = function( col ){
+
+	var i,j,alpha
+	col = col || "000000"
+	this.col( col )
+
+	for( i = 0; i < this.C.field_size.x; i++ ){
+		for( j = 0; j < this.C.field_size.y; j++ ){
+			alpha = 1*this.chemokineIntensity( [i,j] )
+			this.setopacity( alpha*alpha )
+
+			
+			this.pxf( [i,j] )
+		}
+	}
+	this.setopacity( 1 )
+
+}
+
+
+
+/* This allows using the code in either the browser or with nodejs. */
+if( typeof module !== "undefined" ){
+	var DiceSet = require("./DiceSet.js")
+	module.exports = CPM
+}
+


### PR DESCRIPTION
Most important changes:
- Restructured CPM class to new JS class syntax, and added a CPM extension in CPMchemotaxis.js.
This extension should work in both browser and node ( the only problem is that in CPMchemotaxis.js, I have to require CPM.js without declaring a new var - which eslint does not like. But at least it works. ) 
- Added examples of chemotaxis simulations.
- Added some new metrics to CPMStats
- Added a new class BGCanvas for rapid visualization of a fixed background gradient
- Fixed bug in connectivity constraint
- restructured CPM.js so that hamiltonian is computed in a separate method, which can be adjusted dynamically by changing the attribute this.terms.


See ChangeLog for details.